### PR TITLE
feat: add WebAuthn/Passkey authentication support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "be191fedb58fac6a54fd4bf08bf0b808b3d25359cfaf2e09048c35a33c02e8d1",
+  "originHash" : "1e595a8201e8700cafaaa3a96cf0b411cb7503dd0ba6c26d60aa1d4d2397f883",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -299,12 +299,30 @@
       }
     },
     {
+      "identity" : "swiftcbor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/unrelentingtech/SwiftCBOR.git",
+      "state" : {
+        "revision" : "fd929a6d8f7651ce0f63fc99397fd5762358cc29",
+        "version" : "0.6.0"
+      }
+    },
+    {
       "identity" : "vapor",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
         "revision" : "6b7a70a607e61f81214f09130009af4ed76d9d62",
         "version" : "4.119.2"
+      }
+    },
+    {
+      "identity" : "webauthn-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/webauthn-swift.git",
+      "state" : {
+        "revision" : "909cf4193cde7d64196553c4245ab647a68aaaca",
+        "version" : "1.0.0-beta.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/leaf.git", from: "4.5.1"),
         .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.14.0"),
         .package(url: "https://github.com/vapor/queues.git", from: "1.17.2"),
+        .package(url: "https://github.com/swift-server/webauthn-swift.git", from: "1.0.0-beta.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
     ],
     targets: [
@@ -27,6 +28,7 @@ let package = Package(
                 .product(name: "Leaf", package: "leaf"),
                 .product(name: "LeafKit", package: "leaf-kit"),
                 .product(name: "Queues", package: "queues"),
+                .product(name: "WebAuthn", package: "webauthn-swift"),
             ],
             resources: [
                 .copy("Resources/Views"),

--- a/Sources/Passage/Configuration/Configuration+Passkey.swift
+++ b/Sources/Passage/Configuration/Configuration+Passkey.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Vapor
+import WebAuthn
+
+// MARK: - Passkey Configuration
+
+public extension Passage.Configuration {
+
+    struct Passkey: Sendable {
+        let relyingPartyID: String
+        let relyingPartyName: String
+        let relyingPartyOrigin: String
+        let routes: Routes
+        let autoCreateUser: Bool
+        let challengeTimeout: Duration
+        let userVerification: UserVerificationRequirement
+        let attestation: AttestationConveyancePreference
+        let revokeExistingTokens: Bool
+
+        public init(
+            relyingPartyID: String,
+            relyingPartyName: String,
+            relyingPartyOrigin: String,
+            routes: Routes = .init(),
+            autoCreateUser: Bool = true,
+            challengeTimeout: Duration = .seconds(5 * 60),
+            userVerification: UserVerificationRequirement = .preferred,
+            attestation: AttestationConveyancePreference = .none,
+            revokeExistingTokens: Bool = true
+        ) {
+            self.relyingPartyID = relyingPartyID
+            self.relyingPartyName = relyingPartyName
+            self.relyingPartyOrigin = relyingPartyOrigin
+            self.routes = routes
+            self.autoCreateUser = autoCreateUser
+            self.challengeTimeout = challengeTimeout
+            self.userVerification = userVerification
+            self.attestation = attestation
+            self.revokeExistingTokens = revokeExistingTokens
+        }
+    }
+
+}
+
+// MARK: - Passkey Routes
+
+public extension Passage.Configuration.Passkey {
+
+    struct Routes: Sendable {
+
+        public struct RegistrationOptions: Sendable {
+            let path: [PathComponent]
+            public init(path: PathComponent...) {
+                self.path = path
+            }
+        }
+
+        public struct RegistrationVerification: Sendable {
+            let path: [PathComponent]
+            public init(path: PathComponent...) {
+                self.path = path
+            }
+        }
+
+        public struct AuthenticationOptions: Sendable {
+            let path: [PathComponent]
+            public init(path: PathComponent...) {
+                self.path = path
+            }
+        }
+
+        public struct AuthenticationVerification: Sendable {
+            let path: [PathComponent]
+            public init(path: PathComponent...) {
+                self.path = path
+            }
+        }
+
+        public struct SignupOptions: Sendable {
+            let path: [PathComponent]
+            public init(path: PathComponent...) {
+                self.path = path
+            }
+        }
+
+        public struct SignupVerification: Sendable {
+            let path: [PathComponent]
+            public init(path: PathComponent...) {
+                self.path = path
+            }
+        }
+
+        let registrationOptions: RegistrationOptions
+        let registrationVerification: RegistrationVerification
+        let authenticationOptions: AuthenticationOptions
+        let authenticationVerification: AuthenticationVerification
+        let signupOptions: SignupOptions
+        let signupVerification: SignupVerification
+
+        public init(
+            registrationOptions: RegistrationOptions = .init(path: "passkey", "register"),
+            registrationVerification: RegistrationVerification = .init(path: "passkey", "register"),
+            authenticationOptions: AuthenticationOptions = .init(path: "passkey", "authenticate"),
+            authenticationVerification: AuthenticationVerification = .init(path: "passkey", "authenticate"),
+            signupOptions: SignupOptions = .init(path: "passkey", "signup"),
+            signupVerification: SignupVerification = .init(path: "passkey", "signup")
+        ) {
+            self.registrationOptions = registrationOptions
+            self.registrationVerification = registrationVerification
+            self.authenticationOptions = authenticationOptions
+            self.authenticationVerification = authenticationVerification
+            self.signupOptions = signupOptions
+            self.signupVerification = signupVerification
+        }
+    }
+}

--- a/Sources/Passage/Configuration/Passage+Configuration.swift
+++ b/Sources/Passage/Configuration/Passage+Configuration.swift
@@ -16,6 +16,7 @@ extension Passage {
         let restoration: Restoration
         let federatedLogin: FederatedLogin
         let views: Views
+        let passkey: Passkey?
 
         public init(
             origin: URL,
@@ -27,7 +28,8 @@ extension Passage {
             verification: Verification = .init(),
             restoration: Restoration = .init(),
             federatedLogin: FederatedLogin = .init(routes: .init(), providers: []),
-            views: Views = .init()
+            views: Views = .init(),
+            passkey: Passkey? = nil
         ) throws {
             self.origin = origin
             self.routes = routes
@@ -39,6 +41,7 @@ extension Passage {
             self.restoration = restoration
             self.federatedLogin = federatedLogin
             self.views = views
+            self.passkey = passkey
         }
     }
 }

--- a/Sources/Passage/Contracts/Passage+Contracts.swift
+++ b/Sources/Passage/Contracts/Passage+Contracts.swift
@@ -23,6 +23,9 @@ public extension Passage {
         let emailMagicLinkResendForm: any EmailMagicLinkResendForm.Type
         let linkAccountSelectForm: any LinkAccountSelectForm.Type
         let linkAccountVerifyForm: any LinkAccountVerifyForm.Type
+        let passkeySignupBeginForm: any PasskeySignupBeginForm.Type
+        let passkeyAuthenticationFinishForm: any PasskeyAuthenticationFinishForm.Type
+        let passkeySignupFinishForm: any PasskeySignupFinishForm.Type
 
         public init(
             loginForm: (any LoginForm.Type)? = nil,
@@ -45,6 +48,9 @@ public extension Passage {
             emailMagicLinkResendForm: (any EmailMagicLinkResendForm.Type)? = nil,
             linkAccountSelectForm: (any LinkAccountSelectForm.Type)? = nil,
             linkAccountVerifyForm: (any LinkAccountVerifyForm.Type)? = nil,
+            passkeySignupBeginForm: (any PasskeySignupBeginForm.Type)? = nil,
+            passkeyAuthenticationFinishForm: (any PasskeyAuthenticationFinishForm.Type)? = nil,
+            passkeySignupFinishForm: (any PasskeySignupFinishForm.Type)? = nil,
         ) {
             self.loginForm = loginForm ?? DefaultLoginForm.self
             self.logoutForm = logoutForm ?? DefaultLogoutForm.self
@@ -66,6 +72,9 @@ public extension Passage {
             self.emailMagicLinkResendForm = emailMagicLinkResendForm ?? DefaultEmailMagicLinkResendForm.self
             self.linkAccountSelectForm = linkAccountSelectForm ?? DefaultLinkAccountSelectForm.self
             self.linkAccountVerifyForm = linkAccountVerifyForm ?? DefaultLinkAccountVerifyForm.self
+            self.passkeySignupBeginForm = passkeySignupBeginForm ?? DefaultPasskeySignupBeginForm.self
+            self.passkeyAuthenticationFinishForm = passkeyAuthenticationFinishForm ?? DefaultPasskeyAuthenticationFinishForm.self
+            self.passkeySignupFinishForm = passkeySignupFinishForm ?? DefaultPasskeySignupFinishForm.self
         }
     }
 

--- a/Sources/Passage/Errors/AuthenticationError.swift
+++ b/Sources/Passage/Errors/AuthenticationError.swift
@@ -53,6 +53,13 @@ public enum AuthenticationError: Error {
     // Federated account errors
     case federatedAccountAlreadyLinked
     case federatedLoginFailed
+
+    // Passkey errors
+    case passkeyRegistrationFailed
+    case passkeyAuthenticationFailed
+    case passkeyCredentialNotFound
+    case passkeyChallengeNotFound
+    case passkeyNotConfigured
 }
 
 extension AuthenticationError: AbortError {
@@ -100,6 +107,14 @@ extension AuthenticationError: AbortError {
             return .conflict
         case .federatedLoginFailed:
             return .unauthorized
+        case .passkeyRegistrationFailed, .passkeyAuthenticationFailed:
+            return .unauthorized
+        case .passkeyCredentialNotFound:
+            return .notFound
+        case .passkeyChallengeNotFound:
+            return .badRequest
+        case .passkeyNotConfigured:
+            return .internalServerError
         }
     }
 
@@ -171,6 +186,16 @@ extension AuthenticationError: AbortError {
             return "This federated account is already linked to another user."
         case .federatedLoginFailed:
             return "Federated login failed."
+        case .passkeyRegistrationFailed:
+            return "Passkey registration failed."
+        case .passkeyAuthenticationFailed:
+            return "Passkey authentication failed."
+        case .passkeyCredentialNotFound:
+            return "Passkey credential not found."
+        case .passkeyChallengeNotFound:
+            return "Passkey challenge not found or expired."
+        case .passkeyNotConfigured:
+            return "Passkey authentication is not configured."
         }
     }
 }

--- a/Sources/Passage/Features/Passkey/Passage+Passkey.swift
+++ b/Sources/Passage/Features/Passkey/Passage+Passkey.swift
@@ -1,0 +1,288 @@
+import Foundation
+import Vapor
+import WebAuthn
+
+// MARK: - Passkey Namespace
+
+public extension Passage {
+
+    struct Passkey: Sendable {
+        let request: Request
+        let config: Passage.Configuration.Passkey
+    }
+
+}
+
+// MARK: - Service Accessors
+
+extension Passage.Passkey {
+
+    var store: any Passage.Store {
+        request.store
+    }
+
+    var passkeyCredentials: any Passage.PasskeyCredentialStore {
+        get throws {
+            guard let credentials = store.passkeyCredentials else {
+                throw AuthenticationError.passkeyNotConfigured
+            }
+            return credentials
+        }
+    }
+
+    var passkeyChallenges: any Passage.PasskeyChallengeStore {
+        get throws {
+            guard let challenges = store.passkeyChallenges else {
+                throw AuthenticationError.passkeyNotConfigured
+            }
+            return challenges
+        }
+    }
+
+    var webAuthn: WebAuthnManager {
+        request.webAuthn
+    }
+
+    var configuration: Passage.Configuration {
+        request.configuration
+    }
+
+}
+
+// MARK: - Request Extension
+
+extension Request {
+
+    var passkey: Passage.Passkey {
+        get throws {
+            guard let config = configuration.passkey else {
+                throw AuthenticationError.passkeyNotConfigured
+            }
+            return Passage.Passkey(request: self, config: config)
+        }
+    }
+
+}
+
+// MARK: - Registration (Authenticated User)
+
+extension Passage.Passkey {
+
+    func beginRegistration(for user: any User) async throws -> PublicKeyCredentialCreationOptions {
+        let userId = try user.requiredIdAsString
+
+        let userEntity = PublicKeyCredentialUserEntity(
+            id: [UInt8](userId.utf8),
+            name: user.email ?? user.username ?? userId,
+            displayName: user.email ?? user.username ?? userId
+        )
+
+        let options = webAuthn.beginRegistration(
+            user: userEntity,
+            timeout: config.challengeTimeout,
+            attestation: config.attestation
+        )
+
+        try await passkeyChallenges.storeChallenge(
+            options.challenge,
+            for: userId,
+            type: .registration
+        )
+
+        return options
+    }
+
+    func finishRegistration(
+        credential: RegistrationCredential,
+        for user: any User
+    ) async throws {
+        let userId = try user.requiredIdAsString
+
+        guard let challenge = try await passkeyChallenges.retrieveAndDeleteChallenge(
+            for: userId,
+            type: .registration
+        ) else {
+            throw AuthenticationError.passkeyChallengeNotFound
+        }
+
+        let credentialStore = try passkeyCredentials
+
+        do {
+            let verified = try await webAuthn.finishRegistration(
+                challenge: challenge,
+                credentialCreationData: credential,
+                confirmCredentialIDNotRegisteredYet: { credentialId in
+                    let exists = try await credentialStore.credentialExists(id: credentialId)
+                    return !exists
+                }
+            )
+
+            let credentialId = credential.id.asString()
+
+            try await credentialStore.createCredential(
+                id: credentialId,
+                publicKey: verified.publicKey,
+                signCount: verified.signCount,
+                backupEligible: verified.backupEligible,
+                isBackedUp: verified.isBackedUp,
+                for: user
+            )
+        } catch is WebAuthnError {
+            throw AuthenticationError.passkeyRegistrationFailed
+        }
+    }
+
+}
+
+// MARK: - Signup (Unauthenticated)
+
+extension Passage.Passkey {
+
+    func beginSignup(username: String?) async throws -> PublicKeyCredentialCreationOptions {
+        let tempId = UUID().uuidString
+
+        let displayName = username ?? tempId
+
+        let userEntity = PublicKeyCredentialUserEntity(
+            id: [UInt8](tempId.utf8),
+            name: displayName,
+            displayName: displayName
+        )
+
+        let options = webAuthn.beginRegistration(
+            user: userEntity,
+            timeout: config.challengeTimeout,
+            attestation: config.attestation
+        )
+
+        let challengeKey = username ?? tempId
+        try await passkeyChallenges.storeChallenge(
+            options.challenge,
+            for: challengeKey,
+            type: .registration
+        )
+
+        return options
+    }
+
+    func finishSignup(
+        credential: RegistrationCredential,
+        challengeKey: String
+    ) async throws -> AuthUser {
+        guard let challenge = try await passkeyChallenges.retrieveAndDeleteChallenge(
+            for: challengeKey,
+            type: .registration
+        ) else {
+            throw AuthenticationError.passkeyChallengeNotFound
+        }
+
+        let credentialStore = try passkeyCredentials
+
+        let verified: WebAuthn.Credential
+        do {
+            verified = try await webAuthn.finishRegistration(
+                challenge: challenge,
+                credentialCreationData: credential,
+                confirmCredentialIDNotRegisteredYet: { credentialId in
+                    let exists = try await credentialStore.credentialExists(id: credentialId)
+                    return !exists
+                }
+            )
+        } catch {
+            throw AuthenticationError.passkeyRegistrationFailed
+        }
+
+        let user = try await store.users.create(
+            identifier: .username(challengeKey),
+            with: nil
+        )
+
+        let credentialId = credential.id.asString()
+
+        try await credentialStore.createCredential(
+            id: credentialId,
+            publicKey: verified.publicKey,
+            signCount: verified.signCount,
+            backupEligible: verified.backupEligible,
+            isBackedUp: verified.isBackedUp,
+            for: user
+        )
+
+        request.passage.login(user)
+
+        return try await request.tokens.issue(
+            for: user,
+            revokeExisting: config.revokeExistingTokens
+        )
+    }
+
+}
+
+// MARK: - Authentication
+
+extension Passage.Passkey {
+
+    func beginAuthentication() async throws -> PublicKeyCredentialRequestOptions {
+        let sessionId = UUID().uuidString
+
+        let options = webAuthn.beginAuthentication(
+            timeout: config.challengeTimeout,
+            userVerification: config.userVerification
+        )
+
+        try await passkeyChallenges.storeChallenge(
+            options.challenge,
+            for: sessionId,
+            type: .authentication
+        )
+
+        return options
+    }
+
+    func finishAuthentication(
+        credential: AuthenticationCredential,
+        challengeKey: String
+    ) async throws -> AuthUser {
+        let credentialId = credential.id.asString()
+
+        let credentialStore = try passkeyCredentials
+
+        guard let storedCredential = try await credentialStore.findCredential(byId: credentialId) else {
+            throw AuthenticationError.passkeyCredentialNotFound
+        }
+
+        guard let challenge = try await passkeyChallenges.retrieveAndDeleteChallenge(
+            for: challengeKey,
+            type: .authentication
+        ) else {
+            throw AuthenticationError.passkeyChallengeNotFound
+        }
+
+        let verifiedAuth: VerifiedAuthentication
+        do {
+            verifiedAuth = try webAuthn.finishAuthentication(
+                credential: credential,
+                expectedChallenge: challenge,
+                credentialPublicKey: storedCredential.publicKey,
+                credentialCurrentSignCount: storedCredential.currentSignCount
+            )
+        } catch {
+            throw AuthenticationError.passkeyAuthenticationFailed
+        }
+
+        try await credentialStore.updateSignCount(
+            verifiedAuth.newSignCount,
+            for: credentialId
+        )
+
+        let user = storedCredential.user as any User
+
+        request.passage.login(user)
+
+        return try await request.tokens.issue(
+            for: user,
+            revokeExisting: config.revokeExistingTokens
+        )
+    }
+
+}

--- a/Sources/Passage/Features/Passkey/Passkey+RouteCollection.swift
+++ b/Sources/Passage/Features/Passkey/Passkey+RouteCollection.swift
@@ -1,0 +1,130 @@
+import Vapor
+import WebAuthn
+
+extension Passage.Passkey {
+
+    struct RouteCollection: Vapor.RouteCollection, Sendable {
+
+        let routes: Passage.Configuration.Passkey.Routes
+        let group: [PathComponent]
+
+        func boot(routes builder: any RoutesBuilder) throws {
+            let grouped = group.isEmpty ? builder : builder.grouped(group)
+
+            // Registration routes (authenticated)
+            let protected = grouped.grouped(
+                PassageBearerAuthenticator(),
+                PassageGuard()
+            )
+            protected.get(routes.registrationOptions.path, use: beginRegistration)
+            protected.post(routes.registrationVerification.path, use: finishRegistration)
+
+            // Authentication routes (public)
+            grouped.get(routes.authenticationOptions.path, use: beginAuthentication)
+            grouped.post(routes.authenticationVerification.path, use: finishAuthentication)
+
+            // Signup routes (public)
+            grouped.post(routes.signupOptions.path.dropLast() + ["options"], use: beginSignup)
+            grouped.post(routes.signupVerification.path, use: finishSignup)
+        }
+
+    }
+
+}
+
+// MARK: - Registration Handlers
+
+extension Passage.Passkey.RouteCollection {
+
+    @Sendable
+    func beginRegistration(_ req: Request) async throws -> Response {
+        let user = try req.passage.user
+        let passkey = try req.passkey
+        let options = try await passkey.beginRegistration(for: user)
+        let body = try JSONEncoder().encode(options)
+        return Response(
+            status: .ok,
+            headers: ["Content-Type": "application/json"],
+            body: .init(data: body)
+        )
+    }
+
+    @Sendable
+    func finishRegistration(_ req: Request) async throws -> HTTPStatus {
+        let user = try req.passage.user
+        let credential = try req.content.decode(RegistrationCredential.self)
+        let passkey = try req.passkey
+        try await passkey.finishRegistration(credential: credential, for: user)
+        return .ok
+    }
+
+}
+
+// MARK: - Authentication Handlers
+
+extension Passage.Passkey.RouteCollection {
+
+    @Sendable
+    func beginAuthentication(_ req: Request) async throws -> Response {
+        let passkey = try req.passkey
+        let sessionId = UUID().uuidString
+        let options = passkey.webAuthn.beginAuthentication(
+            timeout: passkey.config.challengeTimeout,
+            userVerification: passkey.config.userVerification
+        )
+
+        try await passkey.passkeyChallenges.storeChallenge(
+            options.challenge,
+            for: sessionId,
+            type: .authentication
+        )
+
+        let response = PasskeyBeginAuthenticationResponse(
+            options: options,
+            challengeKey: sessionId
+        )
+        return try await response.encodeResponse(for: req)
+    }
+
+    @Sendable
+    func finishAuthentication(_ req: Request) async throws -> AuthUser {
+        let form = try req.decodeContentAsFormOfType(req.contracts.passkeyAuthenticationFinishForm)
+        let passkey = try req.passkey
+        return try await passkey.finishAuthentication(
+            credential: form.credential,
+            challengeKey: form.challengeKey
+        )
+    }
+
+}
+
+// MARK: - Signup Handlers
+
+extension Passage.Passkey.RouteCollection {
+
+    @Sendable
+    func beginSignup(_ req: Request) async throws -> Response {
+        let form = try req.decodeContentAsFormOfType(req.contracts.passkeySignupBeginForm)
+        let passkey = try req.passkey
+        let challengeKey = form.username ?? UUID().uuidString
+
+        let options = try await passkey.beginSignup(username: form.username)
+
+        let response = PasskeyBeginSignupResponse(
+            options: options,
+            challengeKey: challengeKey
+        )
+        return try await response.encodeResponse(for: req)
+    }
+
+    @Sendable
+    func finishSignup(_ req: Request) async throws -> AuthUser {
+        let form = try req.decodeContentAsFormOfType(req.contracts.passkeySignupFinishForm)
+        let passkey = try req.passkey
+        return try await passkey.finishSignup(
+            credential: form.credential,
+            challengeKey: form.challengeKey
+        )
+    }
+
+}

--- a/Sources/Passage/Features/Passkey/Passkey+WebAuthnManager.swift
+++ b/Sources/Passage/Features/Passkey/Passkey+WebAuthnManager.swift
@@ -1,0 +1,29 @@
+import Vapor
+import WebAuthn
+
+extension Application {
+
+    struct WebAuthnManagerKey: StorageKey {
+        typealias Value = WebAuthnManager
+    }
+
+    var webAuthn: WebAuthnManager {
+        get {
+            guard let manager = storage[WebAuthnManagerKey.self] else {
+                fatalError("WebAuthnManager not configured. Enable passkey in Passage configuration.")
+            }
+            return manager
+        }
+        set {
+            storage[WebAuthnManagerKey.self] = newValue
+        }
+    }
+}
+
+extension Request {
+
+    var webAuthn: WebAuthnManager {
+        application.webAuthn
+    }
+
+}

--- a/Sources/Passage/Inputs/PasskeyForms.swift
+++ b/Sources/Passage/Inputs/PasskeyForms.swift
@@ -1,0 +1,66 @@
+import Vapor
+import WebAuthn
+
+// MARK: - Passkey Signup Begin Form
+
+public protocol PasskeySignupBeginForm: Form {
+    var username: String? { get }
+}
+
+// MARK: - Passkey Authentication Begin Response
+
+struct PasskeyBeginAuthenticationResponse: Content {
+    let options: PublicKeyCredentialRequestOptions
+    let challengeKey: String
+}
+
+// MARK: - Passkey Signup Begin Response
+
+struct PasskeyBeginSignupResponse: Content {
+    let options: PublicKeyCredentialCreationOptions
+    let challengeKey: String
+}
+
+// MARK: - Passkey Authentication Finish Form
+
+public protocol PasskeyAuthenticationFinishForm: Form {
+    var credential: AuthenticationCredential { get }
+    var challengeKey: String { get }
+}
+
+// MARK: - Passkey Signup Finish Form
+
+public protocol PasskeySignupFinishForm: Form {
+    var credential: RegistrationCredential { get }
+    var challengeKey: String { get }
+}
+
+// MARK: - Default Implementations
+
+extension Passage {
+
+    struct DefaultPasskeySignupBeginForm: PasskeySignupBeginForm {
+        static func validations(_ validations: inout Validations) {}
+
+        let username: String?
+    }
+
+    struct DefaultPasskeyAuthenticationFinishForm: PasskeyAuthenticationFinishForm {
+        static func validations(_ validations: inout Validations) {
+            validations.add("challengeKey", as: String.self, is: !.empty)
+        }
+
+        let credential: AuthenticationCredential
+        let challengeKey: String
+    }
+
+    struct DefaultPasskeySignupFinishForm: PasskeySignupFinishForm {
+        static func validations(_ validations: inout Validations) {
+            validations.add("challengeKey", as: String.self, is: !.empty)
+        }
+
+        let credential: RegistrationCredential
+        let challengeKey: String
+    }
+
+}

--- a/Sources/Passage/Protocols/PasskeyCredential.swift
+++ b/Sources/Passage/Protocols/PasskeyCredential.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Passkey Credential
+
+public protocol PasskeyCredential: Sendable {
+    associatedtype UserType: User
+
+    var id: String { get }
+    var publicKey: [UInt8] { get }
+    var currentSignCount: UInt32 { get }
+    var user: UserType { get }
+    var backupEligible: Bool { get }
+    var isBackedUp: Bool { get }
+    var createdAt: Date { get }
+}

--- a/Sources/PassageOnlyForTest/Passage+OnlyForTest.swift
+++ b/Sources/PassageOnlyForTest/Passage+OnlyForTest.swift
@@ -11,14 +11,25 @@ public extension Passage {
             public let restorationCodes: any Passage.RestorationCodeStore
             public let magicLinkTokens: any Passage.MagicLinkTokenStore
             public let exchangeTokens: any Passage.ExchangeTokenStore
+            public let passkeyCredentials: (any Passage.PasskeyCredentialStore)?
+            public let passkeyChallenges: (any Passage.PasskeyChallengeStore)?
 
-            public init() {
+            public init(
+                enablePasskey: Bool = false
+            ) {
                 self.users = InMemoryUserStore()
                 self.tokens = InMemoryTokenStore()
                 self.verificationCodes = InMemoryVerificationStore()
                 self.restorationCodes = InMemoryRestorationStore()
                 self.magicLinkTokens = InMemoryMagicLinkTokenStore()
                 self.exchangeTokens = InMemoryExchangeTokenStore()
+                if enablePasskey {
+                    self.passkeyCredentials = InMemoryPasskeyCredentialStore()
+                    self.passkeyChallenges = InMemoryPasskeyChallengeStore()
+                } else {
+                    self.passkeyCredentials = nil
+                    self.passkeyChallenges = nil
+                }
             }
         }
 


### PR DESCRIPTION
Add passkey integration using swift-server/webauthn-swift, supporting three flows: passkey registration (authenticated), passkey-first signup (unauthenticated), and passkey authentication (login with JWT tokens). Opt-in via Configuration.Passkey with non-breaking Store protocol changes.