### PR TITLE
chore: updates dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "be191fedb58fac6a54fd4bf08bf0b808b3d25359cfaf2e09048c35a33c02e8d1",
+  "originHash" : "4ce6763c58ff6e71ea76c8f6a97aa023fff2f9ce0423663a02c2daec25502006",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "6b7a70a607e61f81214f09130009af4ed76d9d62",
-        "version" : "4.119.2"
+        "revision" : "cfd8f434843ac7850e2d97f46c1aa5ddb906cf1c",
+        "version" : "4.121.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,12 +11,12 @@ let package = Package(
         .library(name: "PassageOnlyForTest", targets: ["PassageOnlyForTest"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.119.2"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.121.4"),
         .package(url: "https://github.com/vapor/jwt.git", from: "5.1.2"),
         .package(url: "https://github.com/vapor/leaf.git", from: "4.5.1"),
-        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.14.0"),
-        .package(url: "https://github.com/vapor/queues.git", from: "1.17.2"),
-        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
+        .package(url: "https://github.com/vapor/leaf-kit.git", from: "1.14.2"),
+        .package(url: "https://github.com/vapor/queues.git", from: "1.18.0"),
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.5"),
     ],
     targets: [
         .target(

--- a/Tests/PassageTests/Integration/Linking/ManualLinkingRouteCollectionIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Linking/ManualLinkingRouteCollectionIntegrationTests.swift
@@ -405,8 +405,6 @@ struct ManualLinkingRouteCollectionIntegrationTests {
             )
             let userId = user.id!.description
 
-            var sessionCookie: String?
-
             // Step 1: Initiate linking
             try await app.testing().test(
                 .POST, "test/initiate-linking",
@@ -423,7 +421,6 @@ struct ManualLinkingRouteCollectionIntegrationTests {
                     let response = try res.content.decode(InitiateLinkingResponse.self)
                     // Without views, should return conflict (can't proceed with manual flow)
                     #expect(response.status == "conflict")
-                    sessionCookie = extractSessionCookie(from: res)
                 }
             )
         }
@@ -717,8 +714,6 @@ struct ManualLinkingRouteCollectionIntegrationTests {
             )
             let userId = user.id!.description
 
-            var sessionCookie: String?
-
             // Initiate - with views=false, returns conflict
             try await app.testing().test(
                 .POST, "test/initiate-linking",
@@ -734,7 +729,6 @@ struct ManualLinkingRouteCollectionIntegrationTests {
                     let response = try res.content.decode(InitiateLinkingResponse.self)
                     // Without views, conflict is returned
                     #expect(response.status == "conflict")
-                    sessionCookie = extractSessionCookie(from: res)
                 }
             )
         }

--- a/Tests/PassageTests/Integration/Linking/ManualLinkingRouteCollectionIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Linking/ManualLinkingRouteCollectionIntegrationTests.swift
@@ -391,8 +391,8 @@ struct ManualLinkingRouteCollectionIntegrationTests {
 
     // MARK: - Link Verify Route Tests (With Session)
 
-    @Test("POST to link/verify with correct password completes linking via route")
-    func postLinkVerifyWithCorrectPasswordCompletesLinking() async throws {
+    @Test("POST to initiate-linking without views returns conflict")
+    func postInitiateLinkingWithoutViewsReturnsConflict() async throws {
         try await withApp(configure: { app in
             try await configureWithManualLinking(app, withViews: false)
         }) { app in
@@ -403,7 +403,6 @@ struct ManualLinkingRouteCollectionIntegrationTests {
                 password: "correct-password",
                 isEmailVerified: true
             )
-            let userId = user.id!.description
 
             // Step 1: Initiate linking
             try await app.testing().test(
@@ -701,8 +700,8 @@ struct ManualLinkingRouteCollectionIntegrationTests {
 
     // MARK: - Redirect URL Tests
 
-    @Test("Successful linking redirects with exchange code via route")
-    func successfulLinkingRedirectsWithExchangeCode() async throws {
+    @Test("Initiating linking returns conflict when views are disabled via route")
+    func initiateLinkingReturnsConflictWhenViewsDisabled() async throws {
         try await withApp(configure: { app in
             try await configureWithManualLinking(app, withViews: false)
         }) { app in
@@ -712,7 +711,6 @@ struct ManualLinkingRouteCollectionIntegrationTests {
                 password: "password123",
                 isEmailVerified: true
             )
-            let userId = user.id!.description
 
             // Initiate - with views=false, returns conflict
             try await app.testing().test(


### PR DESCRIPTION
This pull request focuses on dependency updates and minor cleanup in integration tests. The main change is updating several package dependencies to newer versions, which may bring in bug fixes or new features. Additionally, some unused variables were removed from the integration test code for clarity.

Dependency updates:

* Updated the following package dependencies in `Package.swift`:
  - `vapor` from `4.119.2` to `4.121.4`
  - `leaf-kit` from `1.14.0` to `1.14.2`
  - `queues` from `1.17.2` to `1.18.0`
  - `swift-docc-plugin` from `1.1.0` to `1.4.5`

Test cleanup:

* Removed unused `sessionCookie` variable and related code from `ManualLinkingRouteCollectionIntegrationTests.swift` to simplify the test logic. [[1]](diffhunk://#diff-a9a6d65c4f4253dbb740d8ffb5d599274f819568ac55eb1ff1645eb0b30f696bL408-L409) [[2]](diffhunk://#diff-a9a6d65c4f4253dbb740d8ffb5d599274f819568ac55eb1ff1645eb0b30f696bL426) [[3]](diffhunk://#diff-a9a6d65c4f4253dbb740d8ffb5d599274f819568ac55eb1ff1645eb0b30f696bL720-L721) [[4]](diffhunk://#diff-a9a6d65c4f4253dbb740d8ffb5d599274f819568ac55eb1ff1645eb0b30f696bL737)