### PR TITLE
fix: Passkey signup endpoints are disabled by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
     with:
       with_tsan: false
+      with_api_check: false
     secrets: inherit
 
   submit-dependencies:

--- a/Sources/Passage/Configuration/Configuration+Passkey.swift
+++ b/Sources/Passage/Configuration/Configuration+Passkey.swift
@@ -71,8 +71,8 @@ public extension Passage.Configuration {
             }
 
             public let group: [PathComponent]
-            public let signupBegin: SignupBegin
-            public let signupFinish: SignupFinish
+            public let signupBegin: SignupBegin?
+            public let signupFinish: SignupFinish?
             public let registerBegin: RegisterBegin
             public let registerFinish: RegisterFinish
             public let authenticateBegin: AuthenticateBegin
@@ -80,8 +80,8 @@ public extension Passage.Configuration {
 
             public init(
                 group: [PathComponent] = ["passkey"],
-                signupBegin: SignupBegin = .default,
-                signupFinish: SignupFinish = .default,
+                signupBegin: SignupBegin? = nil,
+                signupFinish: SignupFinish? = nil,
                 registerBegin: RegisterBegin = .default,
                 registerFinish: RegisterFinish = .default,
                 authenticateBegin: AuthenticateBegin = .default,
@@ -139,12 +139,18 @@ public extension Passage.Configuration {
 // MARK: -
 
 extension Passage.Configuration.Passkey.Routes {
-    var signupBeginPath: [PathComponent] {
-        return group + signupBegin.path
+    var signupBeginPath: [PathComponent]? {
+        guard let path = signupBegin?.path else {
+            return nil
+        }
+        return group + path
     }
 
-    var signupFinishPath: [PathComponent] {
-        return group + signupFinish.path
+    var signupFinishPath: [PathComponent]? {
+        guard let path = signupFinish?.path else {
+            return nil
+        }
+        return group + path
     }
 
     var registerBeginPath: [PathComponent] {

--- a/Sources/Passage/Features/Passkey/Passkey+RouteCollection.swift
+++ b/Sources/Passage/Features/Passkey/Passkey+RouteCollection.swift
@@ -12,10 +12,14 @@ extension Passage.Passkey {
 
             grouped.group(routes.group) { group in
                 // Registration ceremony for new users — discoverable, public.
-                group
-                    .post(routes.signupBegin.path, use: self.beginSignup)
-                group
-                    .post(routes.signupFinish.path, use: self.finishSignup)
+                // Opt-in: the routes register only when both sides are set.
+                if let signupBegin = routes.signupBegin,
+                   let signupFinish = routes.signupFinish {
+                    group
+                        .post(signupBegin.path, use: self.beginSignup)
+                    group
+                        .post(signupFinish.path, use: self.finishSignup)
+                }
 
                 // Registration ceremony – discoverable, but requires authentication to initiate and complete.
                 let authed = group
@@ -41,6 +45,9 @@ extension Passage.Passkey {
 extension Passage.Passkey.RouteCollection {
 
     fileprivate func beginSignup(_ req: Request) async throws -> Response {
+        guard let signupBeginPath = routes.signupBeginPath else {
+            throw Abort(.notFound)
+        }
         do {
             let form = try req.decodeContentAsFormOfType(req.contracts.passkeySignupForm)
             let body = try await req.passkey.beginSignup(form: form)
@@ -51,7 +58,7 @@ extension Passage.Passkey.RouteCollection {
 
             return req.views.handlePasskeySignupFormSuccess(
                 of: view,
-                at: groupPath + routes.signupBeginPath,
+                at: groupPath + signupBeginPath,
             )
         } catch {
             guard req.isFormSubmission, req.isWaitingForHTML, let view = req.configuration.views.passkeySignup else {
@@ -60,7 +67,7 @@ extension Passage.Passkey.RouteCollection {
 
             return req.views.handlePasskeySignupFormFailure(
                 of: view,
-                at: groupPath + routes.signupBeginPath,
+                at: groupPath + signupBeginPath,
                 with: error
             )
         }

--- a/Sources/Passage/Features/Views/Passage+PasskeyView.swift
+++ b/Sources/Passage/Features/Views/Passage+PasskeyView.swift
@@ -11,8 +11,14 @@ extension Passage.Views {
         let params = try request.query.decode(PasskeySignupViewParams.self)
 
         let group = request.configuration.routes.group
-        let beginURL = "/" + (group + request.configuration.passkey.routes.signupBeginPath).string
-        let finishURL = "/" + (group + request.configuration.passkey.routes.signupFinishPath).string
+
+        let beginURL = request.configuration.passkey.routes.signupBeginPath.map {
+            "/" + (group + $0).string
+        }
+
+        let finishURL = request.configuration.passkey.routes.signupFinishPath.map {
+            "/" + (group + $0).string
+        }
 
         return try await request.view.render(
             view.template,

--- a/Sources/Passage/Features/Views/Views+RouteCollection.swift
+++ b/Sources/Passage/Features/Views/Views+RouteCollection.swift
@@ -77,8 +77,8 @@ extension Passage.Views {
 
             if let routes = passkey?.routes {
                 grouped.group(routes.group) { group in
-                    if config.passkeySignup != nil {
-                        group.get(routes.signupBegin.path) { req in
+                    if config.passkeySignup != nil, let route = routes.signupBegin {
+                        group.get(route.path) { req in
                             try await req.views.renderPasskeySignupView()
                         }
                     }

--- a/Tests/PassageTests/Integration/Passkey/BeginSignupIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Passkey/BeginSignupIntegrationTests.swift
@@ -34,12 +34,18 @@ struct `Passkey Begin Signup Integration Tests` {
     /// Defaults used across the suite: RP "example.com" on localhost, 5-minute
     /// challenge TTL. Override `passkeyService` to test failure paths or to
     /// assert what the service received.
+    ///
+    /// Signup is opt-in on `Passkey.Routes`; this suite exercises that flow,
+    /// so the default `passkeyRoutes` enables it via `.default` on both sides.
     @Sendable private func configure(
         _ app: Application,
         passkeyService: (any Passage.PasskeyService)? = MockPasskeyService(),
         views: Passage.Configuration.Views = .init(),
         routes: Passage.Configuration.Routes = .init(),
-        passkeyRoutes: Passage.Configuration.Passkey.Routes = .init(),
+        passkeyRoutes: Passage.Configuration.Passkey.Routes = .init(
+            signupBegin: .default,
+            signupFinish: .default
+        ),
         includePasskeyConfig: Bool = true
     ) async throws {
         await app.jwt.keys.add(
@@ -213,6 +219,10 @@ struct `Passkey Begin Signup Integration Tests` {
                     useQueues: false
                 ),
                 passkey: .init(
+                    routes: .init(
+                        signupBegin: .default,
+                        signupFinish: .default
+                    ),
                     policy: policy
                 )
             )
@@ -374,8 +384,11 @@ struct `Passkey Begin Signup Integration Tests` {
 
     @Test
     func `Begin route honors custom registerBegin path from configuration`() async throws {
+        // Signup registers only when both sides are set; pair the custom begin
+        // with the default finish to exercise the override on begin alone.
         let customRoutes = Passage.Configuration.Passkey.Routes(
-            signupBegin: .init(path: "start")
+            signupBegin: .init(path: "start"),
+            signupFinish: .default
         )
 
         try await withApp(configure: { app in

--- a/Tests/PassageTests/Integration/Passkey/FinishSignupIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Passkey/FinishSignupIntegrationTests.swift
@@ -86,7 +86,12 @@ struct `Passkey Finish Signup Integration Tests` {
                 phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
                 useQueues: false
             ),
-            passkey: .init()
+            passkey: .init(
+                routes: .init(
+                    signupBegin: .default,
+                    signupFinish: .default
+                )
+            )
         )
 
         try await app.passage.configure(services: services, configuration: configuration)
@@ -388,7 +393,10 @@ struct `Passkey Finish Signup Integration Tests` {
         // route path. We inline the whole config here to isolate the
         // customization.
         let holder = Holder()
+        // Signup registers only when both sides are set; pair the custom finish
+        // with the default begin to exercise the override on finish alone.
         let customRoutes = Passage.Configuration.Passkey.Routes(
+            signupBegin: .default,
             signupFinish: .init(path: "done")
         )
         try await withApp(configure: { app in

--- a/Tests/PassageTests/Unit/Configuration/PasskeyConfigurationTests.swift
+++ b/Tests/PassageTests/Unit/Configuration/PasskeyConfigurationTests.swift
@@ -67,15 +67,45 @@ struct `Passkey Configuration Tests` {
     // MARK: - Routes
 
     @Test
-    func `Routes defaults: group=passkey, signup and register both have [begin]/[finish]`() {
+    func `Routes defaults: signup is opt-in (nil); register and authenticate keep [begin]/[finish]`() {
         let routes = Passage.Configuration.Passkey.Routes()
         #expect(routes.group.map { $0.description } == ["passkey"])
-        #expect(routes.signupBegin.path.map { $0.description } == ["signup", "begin"])
-        #expect(routes.signupFinish.path.map { $0.description } == ["signup", "finish"])
+        #expect(routes.signupBegin == nil)
+        #expect(routes.signupFinish == nil)
         #expect(routes.registerBegin.path.map { $0.description } == ["register", "begin"])
         #expect(routes.registerFinish.path.map { $0.description } == ["register", "finish"])
         #expect(routes.authenticateBegin.path.map { $0.description } == ["authenticate", "begin"])
         #expect(routes.authenticateFinish.path.map { $0.description } == ["authenticate", "finish"])
+    }
+
+    @Test
+    func `Composed signup paths are nil when signup is disabled (default)`() {
+        let routes = Passage.Configuration.Passkey.Routes()
+        #expect(routes.signupBeginPath == nil)
+        #expect(routes.signupFinishPath == nil)
+    }
+
+    @Test
+    func `Composed signup paths are nil when only one side is set`() {
+        let onlyBegin = Passage.Configuration.Passkey.Routes(signupBegin: .default)
+        #expect(onlyBegin.signupBeginPath?.map { $0.description } == ["passkey", "signup", "begin"])
+        #expect(onlyBegin.signupFinishPath == nil)
+
+        let onlyFinish = Passage.Configuration.Passkey.Routes(signupFinish: .default)
+        #expect(onlyFinish.signupBeginPath == nil)
+        #expect(onlyFinish.signupFinishPath?.map { $0.description } == ["passkey", "signup", "finish"])
+    }
+
+    @Test
+    func `Routes opt-in: signup enabled via .default uses [signup]/[begin] and [signup]/[finish]`() {
+        let routes = Passage.Configuration.Passkey.Routes(
+            signupBegin: .default,
+            signupFinish: .default
+        )
+        #expect(routes.signupBegin?.path.map { $0.description } == ["signup", "begin"])
+        #expect(routes.signupFinish?.path.map { $0.description } == ["signup", "finish"])
+        #expect(routes.signupBeginPath?.map { $0.description } == ["passkey", "signup", "begin"])
+        #expect(routes.signupFinishPath?.map { $0.description } == ["passkey", "signup", "finish"])
     }
 
     @Test
@@ -88,8 +118,8 @@ struct `Passkey Configuration Tests` {
             registerFinish: .init(path: "add-done")
         )
         #expect(routes.group.map { $0.description } == ["pk"])
-        #expect(routes.signupBegin.path.map { $0.description } == ["start"])
-        #expect(routes.signupFinish.path.map { $0.description } == ["done"])
+        #expect(routes.signupBegin?.path.map { $0.description } == ["start"])
+        #expect(routes.signupFinish?.path.map { $0.description } == ["done"])
         #expect(routes.registerBegin.path.map { $0.description } == ["add-start"])
         #expect(routes.registerFinish.path.map { $0.description } == ["add-done"])
     }
@@ -105,8 +135,8 @@ struct `Passkey Configuration Tests` {
             authenticateBegin: .init(path: "a-begin"),
             authenticateFinish: .init(path: "a-finish")
         )
-        #expect(routes.signupBeginPath.map { $0.description } == ["pk", "s-begin"])
-        #expect(routes.signupFinishPath.map { $0.description } == ["pk", "s-finish"])
+        #expect(routes.signupBeginPath?.map { $0.description } == ["pk", "s-begin"])
+        #expect(routes.signupFinishPath?.map { $0.description } == ["pk", "s-finish"])
         #expect(routes.registerBeginPath.map { $0.description } == ["pk", "r-begin"])
         #expect(routes.registerFinishPath.map { $0.description } == ["pk", "r-finish"])
         #expect(routes.authenticateBeginPath.map { $0.description } == ["pk", "a-begin"])


### PR DESCRIPTION
This pull request makes the "signup" passkey routes opt-in, rather than enabled by default. Now, the `signupBegin` and `signupFinish` routes are optional and will only be registered if both are explicitly set. The changes ensure more flexible configuration and safer defaults, and update tests and route handling accordingly.

**Passkey Route Configuration:**

* Made `signupBegin` and `signupFinish` optional (`SignupBegin?`, `SignupFinish?`) in `Passage.Configuration.Passkey.Routes`, with defaults set to `nil`.
* Updated computed properties `signupBeginPath` and `signupFinishPath` to return `nil` if the corresponding route is not set.

**Route Registration Logic:**

* Changed route registration to only add the signup routes if both `signupBegin` and `signupFinish` are set, making signup opt-in.
* Adjusted route handlers to handle the case where signup routes are not present, returning 404 if accessed when disabled.

**View and URL Handling:**

* Updated view logic to safely handle optional signup paths, avoiding errors when signup is disabled.
* Adjusted view route registration to only register the GET handler for signup if the route is enabled.

**Tests and Defaults:**

* Updated and expanded unit and integration tests to reflect the new opt-in behavior, including tests for default (disabled) and partially enabled signup routes [[1]](diffhunk://#diff-892bf819cee93c663ef0bbc0f049c4af48b80022a319ae494ee1f3acda367da1L70-R110) [[2]](diffhunk://#diff-892bf819cee93c663ef0bbc0f049c4af48b80022a319ae494ee1f3acda367da1L91-R122) [[3]](diffhunk://#diff-892bf819cee93c663ef0bbc0f049c4af48b80022a319ae494ee1f3acda367da1L108-R139) [[4]](diffhunk://#diff-96c3cb9e029823d29963d386be7da7501ad751b3654efbcef79e397d8e07e2ebR37-R48) [[5]](diffhunk://#diff-96c3cb9e029823d29963d386be7da7501ad751b3654efbcef79e397d8e07e2ebR222-R225) [[6]](diffhunk://#diff-96c3cb9e029823d29963d386be7da7501ad751b3654efbcef79e397d8e07e2ebR387-R391) [[7]](diffhunk://#diff-d7c126123842935b9b52b30afda6d7b08e04a9d4bd6cecc8b454a35649831ce9L89-R94) [[8]](diffhunk://#diff-d7c126123842935b9b52b30afda6d7b08e04a9d4bd6cecc8b454a35649831ce9R396-R399).

Should fix #42 