### PR TITLE
fix: base64url encoding for magic link tokens

### DIFF
--- a/Sources/Passage/Helpers/Data+Base64URL.swift
+++ b/Sources/Passage/Helpers/Data+Base64URL.swift
@@ -1,0 +1,25 @@
+public import Foundation
+
+// MARK: - base64url Encoding / Decoding
+
+extension Data {
+    /// Standard base64 with `+`→`-`, `/`→`_`, and trailing `=` stripped.
+    /// Produces a URL-safe base64-encoded string per RFC 4648 §5.
+    public func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Decode a base64url-encoded string back into `Data`.
+    /// Accepts strings with or without `=` padding, and normalizes
+    /// `-` → `+` and `_` → `/` before decoding.
+    public init?(base64URLEncoded string: String) {
+        var normalized = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while normalized.count % 4 != 0 { normalized.append("=") }
+        self.init(base64Encoded: normalized)
+    }
+}

--- a/Sources/Passage/Helpers/Data+Base64URL.swift
+++ b/Sources/Passage/Helpers/Data+Base64URL.swift
@@ -1,11 +1,11 @@
-public import Foundation
+import Foundation
 
 // MARK: - base64url Encoding / Decoding
 
 extension Data {
     /// Standard base64 with `+`→`-`, `/`→`_`, and trailing `=` stripped.
     /// Produces a URL-safe base64-encoded string per RFC 4648 §5.
-    public func base64URLEncodedString() -> String {
+    var base64URLEncodedString: String {
         base64EncodedString()
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
@@ -15,7 +15,7 @@ extension Data {
     /// Decode a base64url-encoded string back into `Data`.
     /// Accepts strings with or without `=` padding, and normalizes
     /// `-` → `+` and `_` → `/` before decoding.
-    public init?(base64URLEncoded string: String) {
+    init?(base64URLEncoded string: String) {
         var normalized = string
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")

--- a/Sources/Passage/Services/Passage+Random.swift
+++ b/Sources/Passage/Services/Passage+Random.swift
@@ -20,7 +20,7 @@ public extension Passage {
 struct DefaultRandomGenerator: Passage.RandomGenerator {
 
     func generateRandomString(count: Int) -> String {
-        Data([UInt8].random(count: count)).base64EncodedString()
+        Data([UInt8].random(count: count)).base64URLEncodedString()
     }
     func generateOpaqueToken() -> String {
         generateRandomString(count: 32)

--- a/Sources/Passage/Services/Passage+Random.swift
+++ b/Sources/Passage/Services/Passage+Random.swift
@@ -20,7 +20,7 @@ public extension Passage {
 struct DefaultRandomGenerator: Passage.RandomGenerator {
 
     func generateRandomString(count: Int) -> String {
-        Data([UInt8].random(count: count)).base64URLEncodedString()
+        Data([UInt8].random(count: count)).base64URLEncodedString
     }
     func generateOpaqueToken() -> String {
         generateRandomString(count: 32)

--- a/Sources/Passage/Types/Passkey/WebAuthn.swift
+++ b/Sources/Passage/Types/Passkey/WebAuthn.swift
@@ -47,7 +47,7 @@ extension PublicKeyCredentialUserEntity {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
-        try container.encode(id.base64URLEncodedString, forKey: .id)
+        try container.encode(id.base64URLEncodedString(), forKey: .id)
         try container.encode(displayName, forKey: .displayName)
     }
 
@@ -177,27 +177,6 @@ public enum AttestationConveyancePreference: RawRepresentable, Codable, Sendable
         case .enterprise        : return "enterprise"
         case .unknown(let value): return value
         }
-    }
-}
-
-// MARK: - base64url (WebAuthn binary field format)
-
-extension Data {
-    /// Standard base64 with `+`→`-`, `/`→`_`, and trailing `=` stripped.
-    /// Required for binary fields in the WebAuthn JSON serialization format.
-    var base64URLEncodedString: String {
-        base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-    }
-
-    init?(base64URLEncoded string: String) {
-        var normalized = string
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        while normalized.count % 4 != 0 { normalized.append("=") }
-        self.init(base64Encoded: normalized)
     }
 }
 

--- a/Sources/Passage/Types/Passkey/WebAuthn.swift
+++ b/Sources/Passage/Types/Passkey/WebAuthn.swift
@@ -47,7 +47,7 @@ extension PublicKeyCredentialUserEntity {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
-        try container.encode(id.base64URLEncodedString(), forKey: .id)
+        try container.encode(id.base64URLEncodedString, forKey: .id)
         try container.encode(displayName, forKey: .displayName)
     }
 


### PR DESCRIPTION
The tokens that are used for the magic URLs are base64-encoded. The pluses and slashes mesh don't work in URL as they are transformed by either the browser or by Vapor itself. They should be base64-url encoded, but are not as of yet. This PR fixes that and introduces a moves a generic helper from WebAuthn to the helper directory for that purpose.

Let me know if you see any further issues or if you have any questions.

Cheers!
Lei