### PR TITLE
fix: Remove unwanted creation of session cookie

### DIFF
--- a/Sources/Passage/PassageAuthenticators.swift
+++ b/Sources/Passage/PassageAuthenticators.swift
@@ -38,7 +38,7 @@ public struct PassageSessionAuthenticator: AsyncAuthenticator {
             return try await next.respond(to: request)
         }
 
-        if let aID = request.session.authenticated(request.store.users.userType) {
+        if request.hasSession, let aID = request.session.authenticated(request.store.users.userType) {
             // try to find user with id from session
             let user = try await request.account.user(
                 withId: aID.description

--- a/Tests/PassageTests/Integration/Middleware/SessionAuthenticationIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Middleware/SessionAuthenticationIntegrationTests.swift
@@ -257,6 +257,10 @@ struct `Sessions Authentication Integration Tests` {
                 #expect(res.status == .ok)
                 let body = String(buffer: res.body)
                 #expect(body == "not-authenticated")
+
+                // Check that no session cookie was set
+                let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
+                #expect(!hasSessionCookie)
             })
         }
     }

--- a/Tests/PassageTests/Integration/Middleware/SessionAuthenticationIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Middleware/SessionAuthenticationIntegrationTests.swift
@@ -196,12 +196,10 @@ struct `Sessions Authentication Integration Tests` {
             }, afterResponse: { res async throws in
                 #expect(res.status == .ok)
 
-                // Check that no session cookie was set (or it's empty)
-                let setCookieHeader = res.headers[.setCookie]
-                let hasSessionCookie = setCookieHeader.contains { $0.contains("vapor-session") }
+                // Check that no session cookie was set
+                let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
                 // When sessions are disabled, there should be no session cookie
-                // Note: Vapor might still set an empty session, so we check for the presence
-                #expect(!hasSessionCookie || setCookieHeader.isEmpty)
+                #expect(!hasSessionCookie)
             })
         }
     }


### PR DESCRIPTION
Hello, as I was reading the code I spot an issue that was present in `PassageSessionAuthenticator`: An empty session was created even when not needed.

This apply the same fix given to Vapor's SessionAuthenticator implementation in https://github.com/vapor/vapor/pull/3372.
I have also updated tests to detect any regression.