### PR TITLE
Transactional credential-issuance hooks and stable session id (sid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Versions are git tags; the release workflow reads the latest tag.
+
+## [0.6.0] - 2026-08-28
+
+### Added
+
+- `CredentialIssuance` value type describing a minted credential: `kind` (`.bearer` / `.browser`), `origin` (`.login`, `.magicLink`, `.refresh`, `.exchange`, `.federatedLogin`, `.passkey`, `.accountLinking`), `user`, `sessionId`, `accessToken`, `accessTokenExpiresAt`, `refreshTokenExpiresAt`, `revokedSessionIds`, and the transaction-bound `store`.
+- `Passage.Hooks.Account.willIssueCredential(_:on:)` — runs inside the store transaction after the refresh-token row is written and before commit; a throw rolls the issuance back. `didIssueCredential(_:on:)` runs after commit. Both have no-op defaults and closure forms on `.hook(...)`.
+- `Passage.Hooks.Account.isSessionRevoked(_:on:)` — host-provided check consulted by `PassageBearerAuthenticator` for every JWT that carries a `sid`; returning `true` answers 401 `AuthenticationError.sessionRevoked`. Off by default.
+- `sid` claim on `AccessToken` (`public let sessionId: UUID`) and `RefreshToken.sessionId` (required non-optional `UUID`). `issue` mints a session id; `refresh` carries it onto the replacement refresh token and the new access token.
+- `request.passage.sessionId` — the current session id from the bearer JWT or the cookie session.
+- `request.passage.revoke(sessionId:)` — revokes the refresh-token family; the next refresh fails with `invalidRefreshToken`.
+- `Passage.Store.transaction(_:)`; `Passage.TokenStore.createRefreshToken(for:tokenHash:expiresAt:sessionId:replacing:)`, `revokeRefreshTokens(for:) -> [UUID]`, and `revokeRefreshTokens(sessionId:)`.
+- `Passage.OnlyForTest.InMemoryStore.transaction` snapshots and restores refresh-token rows so hook failures roll back in tests; `InMemoryTokenStore.refreshTokens` lists rows.
+- README section "Session inventory in the host" and matching notes in the Tokens feature guide and `DEVELOPER_NOTES.md`.
+
+### Changed
+
+- Every path that mints a credential (password login, magic-link verify, exchange code, token refresh) now writes the refresh token and runs `willIssueCredential` inside `Store.transaction`.
+- Every login issues exactly one credential, chosen by the route from the client's transport: a form submission accepting `text/html` with the matching view configured gets a `.browser` cookie session; everything else gets a `.bearer` JWT + refresh token. `willIssueCredential`/`didIssueCredential` fire once per login. Previously a login with `sessions.enabled` minted both, leaving an unused refresh-token row behind for HTML clients and setting a cookie for JSON clients.
+- `POST` exchange-code no longer sets a cookie session; the OAuth or passkey callback already did, and the exchange previously overwrote its stored session id.
+- `PassageSessionAuthenticator` consults `isSessionRevoked` with the cookie session's id and signs the session out when the host answers `true`.
+- `issue(for:revokeExisting:)` keeps its default of revoking all of the user's refresh tokens on each sign-in; the affected sessions are now reported to the hook as `revokedSessionIds`.
+- `AuthenticationError` gained `.sessionRevoked` (401).
+
+### Breaking
+
+- `RefreshToken.sessionId` is now a required non-optional `UUID` (was `UUID?` with `nil` default). All refresh tokens must carry a session id.
+- `AccessToken.sessionId` is now a required non-optional `UUID` parameter in the init (was `UUID? = nil`). All access tokens must carry a `sid` claim.
+- `Passage.TokenStore.createRefreshToken(for:tokenHash:expiresAt:sessionId:)` requires `sessionId: UUID` (non-optional). The overloads without `sessionId` have been removed.
+- `Passage.Store.transaction(_:)` is a required protocol member; the best-effort default that ran `body(self)` without rollback has been removed.
+- `Passage.Passwordless.verifyEmailMagicLink(token:)` returns `any User` instead of `AuthUser`. Hosts calling it from their own routes issue the credential with the new public `request.passage.login(_:origin:via:sessionId:revokeExisting:) -> AuthUser?` (`via: .bearer` returns the `AuthUser`; `via: .browser` sets the cookie and returns `nil`).
+- New `Passage.Transport` (`.browser`, `.bearer`).
+- A browser login (`via: .browser`, which the `login`, `magicLinkVerify`, and `linkAccountVerify` views trigger) with `sessions.enabled == false` throws `PassageError.sessionsDisabled` instead of rendering a success page without setting any credential.
+- JSON clients no longer receive a session cookie alongside tokens when sessions are enabled; a browser that needs a cookie submits the form with `Accept: text/html`.
+- Required implementor changes:
+  - **passage-fluent** — `DatabaseStore` must implement `transaction(_:)` via `database.transaction { … }`; `RefreshTokenModel.sessionId` becomes a required `UUID` field with a non-nullable `session_id` column; `DatabaseStore`'s token sub-store adopts the `sessionId: UUID` signatures of `createRefreshToken`. Existing `refresh_tokens` rows without a session id cannot be represented — the migration should delete (or revoke) them, which signs those sessions out.
+  - **custom stores** — same protocol changes; see `DEVELOPER_NOTES.md` › Store.
+  - **passage-imperial**, **passage-mailgun** — unaffected.
+
+### Migration notes
+
+- Access tokens issued before this change carry no `sid` and no longer decode; clients must re-authenticate. Refresh-token rows without a session id must be dropped by the store's migration (see Breaking).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,7 @@ Password reset flows for email/phone. Similar pattern to verification with queue
 - **Configurable routes**: All route paths are customizable via `Configuration.Routes`
 - **Optional queues**: Set `useQueues: true` in verification/restoration config to dispatch jobs async
 - **JWKS configuration**: Load from environment (`JWKS`) or file path (`JWKS_FILE_PATH`)
+
+## Compatibility Policy (IMPORTANT)
+
+Passage is **pre-release**. Breaking changes are welcome; do **not** add backward-compatibility shims (no forwarding defaults on protocol extensions, no deprecated aliases, no dual code paths). When a change breaks a protocol or public type, make it cleanly and list the concrete updates required in each implementor — `passage-fluent`, `passage-imperial`, `passage-mailgun`, and custom stores (`DEVELOPER_NOTES.md`) — under a **Breaking** heading in `CHANGELOG.md`.

--- a/DEVELOPER_NOTES.md
+++ b/DEVELOPER_NOTES.md
@@ -33,15 +33,31 @@ public protocol Store: Sendable {
     var exchangeTokens: any ExchangeTokenStore { get }
     var passkeyCredentials: (any PasskeyCredentialStore)? { get }  // default nil
     var passkeyChallenges: (any PasskeyChallengeStore)? { get }    // default nil
+
+    func transaction<T: Sendable>(
+        _ body: @Sendable (any Store) async throws -> T
+    ) async throws -> T
 }
 ```
+
+### Transactions
+
+`transaction(_:)` is how Passage makes credential issuance atomic: `Passage.Tokens.issue` / `refresh` revoke prior tokens, write the new refresh-token row, and call `Passage.Hooks.Account.willIssueCredential` inside one call to `transaction`, and only commit if the hook returns. Wrap `body` in your database's transaction and hand it a store bound to that transaction; if `body` throws, roll back so the hook's failure leaves no refresh-token row behind.
+
+A transactional store must:
+
+- open a database transaction and hand `body` a store whose every sub-store is bound to it (in `PassageFluent.DatabaseStore` this is `database.transaction { tx in body(self.bound(to: tx)) }`);
+- commit when `body` returns and roll back when it throws, rethrowing the error;
+- tolerate nested calls — sub-store methods such as `createRefreshToken(..., replacing:)` may open their own transaction on the bound database, which must join the outer one rather than start a new one (Fluent's SQL drivers do this).
+
+The store handed to `body` is the one the hook receives as `CredentialIssuance.store`, so a host can cast it back to your concrete type to reach the underlying connection.
 
 ### Sub-stores
 
 | Sub-store | Responsibility |
 |---|---|
 | `UserStore` | User CRUD, identifier lookup, password rotation, account linking (`addIdentifier`), passwordless-only creators (`createWithEmail`, `createWithPhone`). |
-| `TokenStore` | Refresh-token rows with rotation chain (`createRefreshToken(..., replacing:)`), family revocation (`revoke(refreshTokenFamilyStartingFrom:)`). |
+| `TokenStore` | Refresh-token rows with rotation chain (`createRefreshToken(..., sessionId:replacing:)`), family revocation (`revoke(refreshTokenFamilyStartingFrom:)`), session-scoped revocation (`revokeRefreshTokens(sessionId:)`), and user-wide revocation that reports which sessions it retired (`revokeRefreshTokens(for:) -> [UUID]`). |
 | `VerificationCodeStore` | Email + phone verification codes (create/find/invalidate/increment-failed). |
 | `RestorationCodeStore` | Email + phone password-reset codes (same shape as verification). |
 | `MagicLinkTokenStore` | Passwordless email magic-link tokens with optional `sessionTokenHash` for same-browser enforcement. |
@@ -54,6 +70,7 @@ public protocol Store: Sendable {
 - **Hash, don't store plaintext.** Every token and code is persisted as a SHA-256 hash. Refresh tokens, verification codes, reset codes, magic-link tokens, exchange tokens, and passkey challenges all follow this rule. The caller hashes before handing bytes to most sub-stores; `PasskeyChallengeStore` is the one exception — it receives raw `PasskeyChallenge.bytes` and hashes internally (e.g. via a `Data.sha256Hex` helper) so that plain challenge bytes never reach the database layer.
 - **One-shot consumption.** `ExchangeToken`s and `StoredPasskeyChallenge`s must set a `consumedAt` timestamp on use and reject subsequent reads. Cleanup methods (`cleanupExpiredTokens(before:)`, `cleanupExpiredPasskeyChallenges(before:)`) let you run periodic sweeps.
 - **Refresh-token family revocation.** Token rotation links the old token's `replacedBy` field to the new row. On reuse (i.e. a rotated-away hash is presented again), follow the chain and revoke the entire family via `revoke(refreshTokenFamilyStartingFrom:)`.
+- **Session ids name the family.** `RefreshToken.sessionId` is the `sid` claim of the access tokens minted with that row; every row in a rotation chain shares it. Persist the value passed to `createRefreshToken(for:tokenHash:expiresAt:sessionId:replacing:)` — the parameter is required (non-optional `UUID`). `revokeRefreshTokens(for:)` must return the distinct session ids of the rows it flipped. `revokeRefreshTokens(sessionId:)` revokes all refresh tokens for a given session.
 - **Eager loading.** When `UserStore.find(byIdentifier:)` is called, load the identifier's user along with its other identifiers if you need account-linking semantics — otherwise downstream features (federated login, linking, passkeys) will issue extra queries per request.
 
 ### Reference implementations

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ try await app.passage.configure(
 )
 ```
 
-**`willIssueCredential(_:on:)`** runs after the access token is signed and the refresh-token row is written, inside the same store transaction, before commit. A throw aborts the transaction: no refresh-token row, no credential returned, and the route answers the thrown error. Use `issuance.store` — the transaction-bound store — for your own writes; with PassageFluent that is `(issuance.store as? DatabaseStore)?.database`.
+**`willIssueCredential(_:on:)`** runs inside the store transaction before commit. For `.bearer` credentials it runs after the access token is signed and the refresh-token row is written; for `.browser` credentials it runs before the session cookie is set. A throw aborts the transaction: no refresh-token row (for `.bearer`), no credential returned, and the route answers the thrown error. Use `issuance.store` — the transaction-bound store — for your own writes; with PassageFluent that is `(issuance.store as? DatabaseStore)?.database.
 
 **`didIssueCredential(_:on:)`** runs after commit and cannot throw. Put side effects that must not roll issuance back here (analytics, mail).
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Use with caution. The library is functional, but the API is subject to change be
 - 📋 **Web Forms** - Built-in Leaf templates for registration, login, and password reset
 - ⚡ **Async Queue Support** - Optional background job processing via Vapor Queues
 - 🔧 **Protocol-Based Services** - Pluggable storage, email, phone, and OAuth providers
-- 🪝 **Lifecycle Hooks** - Async will/did callbacks for custom policy and audit
+- 🪝 **Lifecycle Hooks** - Async will/did callbacks for custom policy and audit, including a transactional credential-issuance hook
+- 🗂️ **Session Inventory** - Stable `sid` claim across refresh, session-scoped revocation, and a host-provided revocation check
 - 🎨 **Fully Customizable** - Configure routes, tokens, templates, and behavior
 
 ## Standards Compliance
@@ -132,7 +133,7 @@ Passage is designed for flexibility through:
 - **Protocol-Based Services** - Implement your own storage, email delivery, phone delivery, or OAuth providers
 - **Extensible Forms** - Default form types can be replaced with custom implementations via contracts
 - **Stylable Default Views** - Default Leaf views with different styles and themes
-- **Lifecycle Hooks** - Inject async pre/post callbacks around authentication flows; throw from `will*` hooks to gate flows on custom policy
+- **Lifecycle Hooks** - Inject async pre/post callbacks around authentication flows; throw from `will*` hooks to gate flows on custom policy, or from `willIssueCredential` to roll a sign-in back inside the store transaction
 
 ## Services to Implement
 
@@ -278,6 +279,96 @@ Over-limit requests return **`429 Too Many Requests`** with a `Retry-After` head
 
 #### Feature guide
 Configuration: [`Sources/Passage/Configuration/Configuration+Throttle.swift`](./Sources/Passage/Configuration/Configuration+Throttle.swift). Middleware: [`Sources/Passage/LoginThrottleMiddleware.swift`](./Sources/Passage/LoginThrottleMiddleware.swift). Per-identifier enforcement lives in the login service at [`Sources/Passage/Features/Account/Passage+Account.swift`](./Sources/Passage/Features/Account/Passage+Account.swift).
+
+#### Example
+_No dedicated example yet — see [rozd/passage-example](https://github.com/rozd/passage-example) for the canonical walkthrough._
+</details>
+
+<details>
+<summary><h3>🗂️ Session inventory in the host</h3> — record every live credential in your own tables, atomically with issuance.</summary>
+
+#### Configuration
+A host that keeps its own session inventory — list a user's devices, revoke one of them, including a credential that was never used after sign-in — used to learn about a new credential only by inspecting the HTTP response after Passage had already committed it. That is a dual write. If the host's bookkeeping fails, either the login answers 5xx while the token is already live (the client retries and mints more live tokens), or the host swallows the error and the token exists outside its inventory until its first authenticated request. Both are wrong, and neither is fixable from outside Passage. Two things remove the dual write: an issuance hook that runs **inside** the store transaction, and a stable session id (`sid`) that names the refresh-token family.
+
+```swift
+try await app.passage.configure(
+    services: .init(/* ... */),
+    configuration: .init(/* ... */),
+    hooks: .init(
+        account: .hook(
+            willIssueCredential: { issuance, request in
+                let db = (issuance.store as? DatabaseStore)?.database ?? request.db
+                try await HostSession(
+                    id: issuance.sessionId,
+                    userId: try issuance.user.requiredIdAsString,
+                    kind: issuance.kind == .bearer ? "bearer" : "browser",
+                    expiresAt: issuance.refreshTokenExpiresAt,
+                    device: request.headers.first(name: .userAgent)
+                ).save(on: db)
+                try await HostSession.query(on: db)
+                    .filter(\.$id ~~ issuance.revokedSessionIds)
+                    .set(\.$revokedAt, to: .now)
+                    .update()
+            },
+            didIssueCredential: { issuance, request in
+                try? await analytics.track(.signIn, origin: issuance.origin, user: issuance.user)
+            },
+            isSessionRevoked: { sessionId, request in
+                (try? await HostSession.find(sessionId, on: request.db))?.revokedAt != nil
+            }
+        )
+    )
+)
+```
+
+**`willIssueCredential(_:on:)`** runs after the access token is signed and the refresh-token row is written, inside the same store transaction, before commit. A throw aborts the transaction: no refresh-token row, no credential returned, and the route answers the thrown error. Use `issuance.store` — the transaction-bound store — for your own writes; with PassageFluent that is `(issuance.store as? DatabaseStore)?.database`.
+
+**`didIssueCredential(_:on:)`** runs after commit and cannot throw. Put side effects that must not roll issuance back here (analytics, mail).
+
+Every login issues exactly one credential and fires the hooks exactly once for it. The route decides which credential from the transport the client can use:
+
+| Request                                                           | Credential                                   | `kind`     |
+|-------------------------------------------------------------------|----------------------------------------------|------------|
+| Form submission accepting `text/html`, with the matching view configured | Cookie session (requires `sessions.enabled`) | `.browser` |
+| Anything else (JSON body, no view, API client)                    | JWT + refresh token                          | `.bearer`  |
+
+Password login, magic-link verify, and manual account linking follow this rule. Federated login and passkey authentication set the cookie session for the browser (when sessions are enabled) and hand API clients an exchange code; the later `POST` exchange issues the `.bearer` credential and never touches the cookie. Token refresh is always `.bearer`. A `.bearer` issuance therefore always means the client received those tokens, and a `.browser` issuance always means a cookie was set — there is no discarded credential to filter out.
+
+A browser login while `sessions.enabled` is `false` fails with `PassageError.sessionsDisabled` rather than rendering a success page with no credential behind it: the `login`, `magicLinkVerify`, and `linkAccountVerify` views can only sign a browser in with a cookie.
+
+Hosts that authenticate users from their own routes call the same helper the built-in routes use:
+
+```swift
+let user = try await req.passwordless.verifyEmailMagicLink(token: token)
+let authUser = try await req.passage.login(user, origin: .magicLink, via: .bearer)
+```
+
+`request.passage.login(_:origin:via:sessionId:revokeExisting:)` returns the `AuthUser` for `.bearer` and `nil` for `.browser`.
+
+`CredentialIssuance` fields:
+
+| Field                   | Meaning                                                                                                   |
+|-------------------------|-----------------------------------------------------------------------------------------------------------|
+| `kind`                  | `.bearer` (JWT + refresh token) or `.browser` (cookie session; token fields are `nil`)                    |
+| `origin`                | `.login`, `.magicLink`, `.refresh`, `.exchange`, `.federatedLogin`, `.passkey`, `.accountLinking`          |
+| `user`                  | The user the credential belongs to                                                                        |
+| `sessionId`             | The `sid`; new on `issue`, carried forward on `refresh`                                                   |
+| `accessToken`           | The signed JWT (`.bearer` only)                                                                           |
+| `accessTokenExpiresAt`  | `exp` of the JWT (`.bearer` only)                                                                         |
+| `refreshTokenExpiresAt` | Expiry of the refresh-token row (`.bearer` only)                                                          |
+| `revokedSessionIds`     | Sessions whose refresh tokens this sign-in revoked (see below); retire those rows in the same transaction |
+| `store`                 | The store bound to the transaction the hook runs in                                                       |
+
+**`sid`.** Every access token carries a `sid` claim (UUID string) and every refresh-token row stores the same `sessionId`. `issue` mints a new one; `refresh` copies it onto the replacement refresh token and the new access token, so a session keeps its name across rotations. The refresh-token family already existed (`revoke(refreshTokenFamilyStartingFrom:)`); `sid` is its name. Read it on an authenticated request with `request.passage.sessionId` — from the bearer JWT, or from the cookie session for browser logins.
+
+**Revocation.** `try await request.passage.revoke(sessionId:)` revokes the family; the next refresh with any of its tokens fails with `invalidRefreshToken`. To reject an already-issued JWT before its `exp`, or to sign a cookie session out, implement `isSessionRevoked` against your own revocation table — it is consulted by `PassageBearerAuthenticator` on every request whose JWT carries a `sid` and by `PassageSessionAuthenticator` for every cookie session that stored one, is off by default, and keeps Passage from growing a denylist of its own.
+
+**`revokeExisting`.** `issue(for:revokeExisting:)` defaults to `true`: every sign-in revokes all of the user's existing refresh tokens (the magic-link flow exposes this as `revokeExistingTokens` in its configuration). The hook reports the affected sessions in `revokedSessionIds` so your inventory can retire them atomically.
+
+**Transactional guarantee.** `Passage.Store.transaction(_:)` is a required protocol member: `PassageFluent.DatabaseStore` wraps issuance in `database.transaction { … }`, and a custom store must do the equivalent so a throwing hook rolls the refresh-token row back; see [DEVELOPER_NOTES.md](./DEVELOPER_NOTES.md#store).
+
+#### Feature guide
+See [`Sources/Passage/Features/Tokens/README.md`](./Sources/Passage/Features/Tokens/README.md) for the claim table and the issue / refresh ordering, and [`Sources/Passage/Types/CredentialIssuance.swift`](./Sources/Passage/Types/CredentialIssuance.swift) for the value type.
 
 #### Example
 _No dedicated example yet — see [rozd/passage-example](https://github.com/rozd/passage-example) for the canonical walkthrough._
@@ -619,16 +710,19 @@ try await app.passage.configure(
 
 Hook protocols expose `will*` / `did*` pairs around each flow. `will*` methods are `async throws` and abort the flow when they throw; `did*` methods are non-throwing observers that fire after the underlying step has succeeded. All methods have empty default implementations, so a custom hook type only overrides the events it cares about. The `.hook(...)` factory shown above is convenient for ad-hoc wiring; for richer behavior conform a type to the protocol directly.
 
-**`Passage.Hooks.Account`** — Account flows (register / login / logout):
+**`Passage.Hooks.Account`** — Account flows (register / login / logout) and credential issuance:
 
-| Hook                | Fires…                                                              |
-|---------------------|---------------------------------------------------------------------|
-| `willRegister`      | Before password validation and user creation                        |
-| `didRegister`       | After user creation, before the verification code is dispatched     |
-| `willLogin`         | After credentials succeed, before the session is established        |
-| `didLogin`          | After the session is established, before access tokens are issued   |
-| `willLogout`        | Before the session is cleared                                       |
-| `didLogout`         | After the session is cleared, before the refresh token is revoked   |
+| Hook                  | Fires…                                                                                              |
+|-----------------------|-----------------------------------------------------------------------------------------------------|
+| `willRegister`        | Before password validation and user creation                                                        |
+| `didRegister`         | After user creation, before the verification code is dispatched                                     |
+| `willLogin`           | After credentials succeed, before the session is established                                        |
+| `didLogin`            | After the session is established, before access tokens are issued                                   |
+| `willLogout`          | Before the session is cleared                                                                       |
+| `didLogout`           | After the session is cleared, before the refresh token is revoked                                   |
+| `willIssueCredential` | Inside the store transaction, after the refresh-token row is written, before commit — throw to abort |
+| `didIssueCredential`  | After the transaction commits; non-throwing                                                         |
+| `isSessionRevoked`    | On every bearer request whose JWT carries a `sid`; return `true` to reject it with 401              |
 
 `willLogin` fires **after** the password check passes — it is the gate where you enforce post-authentication policy (account suspension, license expiry, forced MFA), not credential validation.
 

--- a/Sources/Passage/Errors/AuthenticationError.swift
+++ b/Sources/Passage/Errors/AuthenticationError.swift
@@ -21,6 +21,7 @@ public enum AuthenticationError: Error, Equatable {
     case invalidRefreshToken
     case refreshTokenExpired
     case refreshTokenNotFound
+    case sessionRevoked
 
     // User errors
     case userNotFound
@@ -76,7 +77,7 @@ extension AuthenticationError: AbortError {
             return .forbidden
         case .passwordIsNotSet:
             return .internalServerError
-        case .invalidRefreshToken, .refreshTokenExpired:
+        case .invalidRefreshToken, .refreshTokenExpired, .sessionRevoked:
             return .unauthorized
         case .refreshTokenNotFound, .userNotFound:
             return .notFound
@@ -149,6 +150,8 @@ extension AuthenticationError: AbortError {
             return "The refresh token is invalid."
         case .refreshTokenExpired:
             return "The refresh token has expired."
+        case .sessionRevoked:
+            return "The session has been revoked."
         case .refreshTokenNotFound:
             return "Refresh token not found."
         case .userNotFound:

--- a/Sources/Passage/Errors/PassageError.swift
+++ b/Sources/Passage/Errors/PassageError.swift
@@ -8,6 +8,7 @@ public enum PassageError: Error {
     case phoneDeliveryNotConfigured
     case emailMagicLinkNotConfigured
     case passkeyNotConfigured
+    case sessionsDisabled
     case missingEnvironmentVariable(name: String)
     case unexpected(message: String)
     case passkeyServiceNotAvailable
@@ -24,7 +25,7 @@ public enum PassageError: Error {
 extension PassageError: AbortError {
     public var status: HTTPResponseStatus {
         switch self {
-        case .notConfigured, .storeNotConfigured, .jwksNotConfigured, .emailDeliveryNotConfigured, .phoneDeliveryNotConfigured, .emailMagicLinkNotConfigured, .passkeyNotConfigured, .unexpected, .passkeyServiceNotAvailable:
+        case .notConfigured, .storeNotConfigured, .jwksNotConfigured, .emailDeliveryNotConfigured, .phoneDeliveryNotConfigured, .emailMagicLinkNotConfigured, .passkeyNotConfigured, .sessionsDisabled, .unexpected, .passkeyServiceNotAvailable:
             return .internalServerError
         case .missingEnvironmentVariable(name: _):
             return .internalServerError
@@ -49,6 +50,8 @@ extension PassageError: AbortError {
             return "Email magic link is not configured. Provide emailMagicLink in passwordless configuration."
         case .passkeyNotConfigured:
             return "Passkey is not configured. Provide passkey in app.passage.configure()."
+        case .sessionsDisabled:
+            return "Sessions are disabled. Enable sessions in configuration to sign browsers in with a cookie."
         case .unexpected(let message):
             return message
         case .missingEnvironmentVariable(name: let name):

--- a/Sources/Passage/Features/Account/Account+RouteCollection.swift
+++ b/Sources/Passage/Features/Account/Account+RouteCollection.swift
@@ -74,8 +74,17 @@ extension Passage.Account.RouteCollection {
             let user = try await req.account.login(form: form)
 
             guard req.isFormSubmission, req.isWaitingForHTML, let view = req.configuration.views.login else {
-                return try await user.encodeResponse(for: req)
+                guard let authUser = try await req.passage.login(
+                    user,
+                    origin: .login,
+                    via: .bearer,
+                ) else {
+                    throw Abort(.internalServerError)
+                }
+                return try await authUser.encodeResponse(for: req)
             }
+
+            _ = try await req.passage.login(user, origin: .login, via: .browser)
 
             return req.views.handleLoginFormSuccess(
                 of: view,

--- a/Sources/Passage/Features/Account/Passage+Account.swift
+++ b/Sources/Passage/Features/Account/Passage+Account.swift
@@ -66,7 +66,7 @@ extension Passage.Account {
 
 extension Passage.Account {
 
-    func login(form: any LoginForm) async throws -> AuthUser {
+    func login(form: any LoginForm) async throws -> any User {
         let identifier = try form.asIdentifier()
         let rules = configuration.throttle.login
         let now = Date()
@@ -105,11 +105,9 @@ extension Passage.Account {
 
         try await request.hooks.account?.willLogin(user: user, on: request)
 
-        request.passage.login(user)
-
         await request.hooks.account?.didLogin(user: user, on: request)
 
-        return try await request.tokens.issue(for: user)
+        return user
     }
 
 }

--- a/Sources/Passage/Features/FederatedLogin/Passage+FederatedLogin.swift
+++ b/Sources/Passage/Features/FederatedLogin/Passage+FederatedLogin.swift
@@ -92,8 +92,10 @@ extension Passage.FederatedLogin {
 
     /// Complete login by issuing tokens and redirecting
     private func completeLogin(for user: any User) async throws -> Response {
-        // Session authentication (for SSR)
-        request.passage.login(user)
+        // Session authentication (for SSR) if enabled
+        if request.configuration.sessions.enabled {
+            _ = try await request.passage.login(user, origin: .federatedLogin, via: .browser)
+        }
 
         // Build redirect URL with generated exchange code for API clients
         let redirectURL = buildRedirectURL(

--- a/Sources/Passage/Features/Linking/Linking+ManualLinking.swift
+++ b/Sources/Passage/Features/Linking/Linking+ManualLinking.swift
@@ -117,8 +117,6 @@ extension Passage.Linking.ManualLinking {
 
         clearLinkingState()
 
-        request.passage.login(user)
-        
         return user
     }
 

--- a/Sources/Passage/Features/Linking/Linking+ManualLinkingRouteCollection.swift
+++ b/Sources/Passage/Features/Linking/Linking+ManualLinkingRouteCollection.swift
@@ -59,6 +59,8 @@ extension Passage.Linking {
                         return req.redirect(to: redirectURL)
                     }
 
+                    _ = try await req.passage.login(user, origin: .accountLinking, via: .browser)
+
                     return req.views.handleLinkAccountVerifyFormSubmit(
                         of: view,
                         at: group + configuration.federatedLogin.linkAccountVerifyPath,

--- a/Sources/Passage/Features/Passkey/Passage+Passkey.swift
+++ b/Sources/Passage/Features/Passkey/Passage+Passkey.swift
@@ -256,7 +256,9 @@ extension Passage.Passkey {
         )
         try await challenges.consume(passkeyChallenge: result.matchedChallenge)
 
-        request.passage.login(user)
+        if request.configuration.sessions.enabled {
+            _ = try await request.passage.login(user, origin: .passkey, via: .browser)
+        }
         let code = try await request.tokens.createExchangeCode(for: user)
 
         await request.hooks.passkey?.didFinishAuthentication(

--- a/Sources/Passage/Features/Passwordless/Passage+Passwordless.swift
+++ b/Sources/Passage/Features/Passwordless/Passage+Passwordless.swift
@@ -124,10 +124,7 @@ extension Passage.Passwordless {
 
 extension Passage.Passwordless {
 
-    /// Verify an email magic link and authenticate the user
-    /// - Parameter token: The magic link token from the URL
-    /// - Returns: AuthUser containing access and refresh tokens
-    public func verifyEmailMagicLink(token: String) async throws -> AuthUser {
+    public func verifyEmailMagicLink(token: String) async throws -> any User {
         guard let config = self.config.emailMagicLink else {
             throw PassageError.emailMagicLinkNotConfigured
         }
@@ -177,9 +174,7 @@ extension Passage.Passwordless {
             request.session.data[magicLinkSessionTokenKey] = nil
         }
 
-        request.passage.login(user)
-
-        return try await request.tokens.issue(for: user, revokeExisting: self.config.revokeExistingTokens)
+        return user
     }
 
     /// Verify that the magic link is being verified from the same browser

--- a/Sources/Passage/Features/Passwordless/Passwordless+MagicLinkRouteCollection.swift
+++ b/Sources/Passage/Features/Passwordless/Passwordless+MagicLinkRouteCollection.swift
@@ -66,11 +66,26 @@ extension Passage.Passwordless.MagicLinkEmailRouteCollection {
     func verify(_ req: Request) async throws -> Response {
         do {
             let form = try req.decodeQueryAsFormOfType(req.contracts.emailMagicLinkVerifyForm)
-            let authUser = try await req.passwordless.verifyEmailMagicLink(token: form.token)
+            let user = try await req.passwordless.verifyEmailMagicLink(token: form.token)
 
             guard let view = req.configuration.views.magicLinkVerify else {
+                guard let authUser = try await req.passage.login(
+                    user,
+                    origin: .magicLink,
+                    via: .bearer,
+                    revokeExisting: req.configuration.passwordless.revokeExistingTokens
+                ) else {
+                    throw Abort(.internalServerError)
+                }
                 return try await authUser.encodeResponse(for: req)
             }
+
+            _ = try await req.passage.login(
+                user,
+                origin: .magicLink,
+                via: .browser,
+                revokeExisting: req.configuration.passwordless.revokeExistingTokens
+            )
 
             let html = try await req.views.renderMagicLinkVerifySuccess(
                 of: view,

--- a/Sources/Passage/Features/Passwordless/README.md
+++ b/Sources/Passage/Features/Passwordless/README.md
@@ -125,8 +125,13 @@ sequenceDiagram
     end
 
     Passage->>Store: Invalidate magic link
-    Passage->>Passage: Issue tokens
-    Passage-->>App: AuthUser (tokens)
+    Passage-->>App: User
+    App->>Passage: passage.login(user, origin: .magicLink, via:)
+    alt Verify view configured (browser)
+        Passage-->>App: Cookie session set
+    else API client
+        Passage-->>App: AuthUser (tokens)
+    end
     App-->>User: Authenticated
 ```
 

--- a/Sources/Passage/Features/Tokens/Passage+Tokens.swift
+++ b/Sources/Passage/Features/Tokens/Passage+Tokens.swift
@@ -42,37 +42,16 @@ extension Passage.Tokens {
 
     func issue(
         for user: any User,
-        revokeExisting: Bool = true
+        sessionId: UUID,
+        revokeExisting: Bool = true,
+        origin: CredentialIssuance.Origin
     ) async throws -> AuthUser {
-        if revokeExisting {
-            try await revoke(for: user)
-        }
-
-        let accessToken = AccessToken(
-            userId: try user.requiredIdAsString,
-            expiresAt: .now.addingTimeInterval(configuration.accessToken.timeToLive),
-            issuer: configuration.issuer,
-            audience: nil,
-            scope: nil
-        )
-
-        let opaqueToken = random.generateOpaqueToken()
-        try await store.tokens.createRefreshToken(
+        try await mint(
             for: user,
-            tokenHash: random.hashOpaqueToken(token: opaqueToken),
-            expiresAt: .now.addingTimeInterval(configuration.refreshToken.timeToLive)
-        )
-
-        return AuthUser(
-            accessToken: try await request.jwt.sign(accessToken),
-            refreshToken: opaqueToken,
-            tokenType: "Bearer",
-            expiresIn: configuration.accessToken.timeToLive,
-            user: .init(
-                id: try user.requiredIdAsString,
-                email: user.email,
-                phone: user.phone
-            )
+            sessionId: sessionId,
+            origin: origin,
+            revokeExisting: revokeExisting,
+            replacing: nil
         )
     }
 
@@ -94,26 +73,83 @@ extension Passage.Tokens {
             throw AuthenticationError.invalidRefreshToken
         }
 
-        let user = refreshToken.user
-
-        let opaqueToken = random.generateOpaqueToken()
-        try await store.tokens.createRefreshToken(
-            for: user,
-            tokenHash: random.hashOpaqueToken(token: opaqueToken),
-            expiresAt: .now.addingTimeInterval(configuration.refreshToken.timeToLive),
+        return try await mint(
+            for: refreshToken.user,
+            sessionId: refreshToken.sessionId,
+            origin: .refresh,
+            revokeExisting: false,
             replacing: refreshToken
         )
+    }
+
+}
+
+// MARK: - Mint
+
+extension Passage.Tokens {
+
+    private func mint(
+        for user: any User,
+        sessionId: UUID,
+        origin: CredentialIssuance.Origin,
+        revokeExisting: Bool,
+        replacing tokenToReplace: (any RefreshToken)?
+    ) async throws -> AuthUser {
+        let now = Date.now
+        let accessTokenExpiresAt = now.addingTimeInterval(configuration.accessToken.timeToLive)
+        let refreshTokenExpiresAt = now.addingTimeInterval(configuration.refreshToken.timeToLive)
 
         let accessToken = AccessToken(
             userId: try user.requiredIdAsString,
-            expiresAt: .now.addingTimeInterval(configuration.accessToken.timeToLive),
+            issuedAt: now,
+            expiresAt: accessTokenExpiresAt,
             issuer: configuration.issuer,
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: sessionId
         )
+        let signedAccessToken = try await request.jwt.sign(accessToken)
+
+        let opaqueToken = random.generateOpaqueToken()
+        let opaqueTokenHash = random.hashOpaqueToken(token: opaqueToken)
+
+        let request = self.request
+        let hooks = request.hooks.account
+
+        let issuance = try await store.transaction { store in
+            let revokedSessionIds = revokeExisting
+                ? try await store.tokens.revokeRefreshTokens(for: user)
+                : []
+
+            try await store.tokens.createRefreshToken(
+                for: user,
+                tokenHash: opaqueTokenHash,
+                expiresAt: refreshTokenExpiresAt,
+                sessionId: sessionId,
+                replacing: tokenToReplace
+            )
+
+            let issuance = CredentialIssuance(
+                kind: .bearer,
+                origin: origin,
+                user: user,
+                sessionId: sessionId,
+                accessToken: signedAccessToken,
+                accessTokenExpiresAt: accessTokenExpiresAt,
+                refreshTokenExpiresAt: refreshTokenExpiresAt,
+                revokedSessionIds: revokedSessionIds,
+                store: store
+            )
+
+            try await hooks?.willIssueCredential(issuance, on: request)
+
+            return issuance
+        }
+
+        await hooks?.didIssueCredential(issuance, on: request)
 
         return AuthUser(
-            accessToken: try await request.jwt.sign(accessToken),
+            accessToken: signedAccessToken,
             refreshToken: opaqueToken,
             tokenType: "Bearer",
             expiresIn: configuration.accessToken.timeToLive,
@@ -132,7 +168,11 @@ extension Passage.Tokens {
 extension Passage.Tokens {
 
     func revoke(for user: any User) async throws {
-        try await store.tokens.revokeRefreshToken(for: user)
+        try await store.tokens.revokeRefreshTokens(for: user)
+    }
+
+    func revoke(sessionId: UUID) async throws {
+        try await store.tokens.revokeRefreshTokens(sessionId: sessionId)
     }
 
 }
@@ -197,10 +237,7 @@ extension Passage.Tokens {
         // Get user from token
         let user = exchangeToken.user
 
-        // Authenticate user in session (if sessions enabled)
-        request.passage.login(user)
-
         // Issue full JWT tokens
-        return try await issue(for: user)
+        return try await issue(for: user, sessionId: UUID(), origin: .exchange)
     }
 }

--- a/Sources/Passage/Features/Tokens/README.md
+++ b/Sources/Passage/Features/Tokens/README.md
@@ -7,10 +7,11 @@ JWT access token issuance, opaque refresh token management, and token exchange f
 The Tokens feature manages authentication tokens throughout their lifecycle. It handles issuing JWT access tokens for API authentication, rotating refresh tokens for session continuity, and one-time exchange codes for OAuth redirect flows. Token rotation with family revocation provides security against token theft.
 
 **Key capabilities:**
-- JWT access tokens with standard claims (sub, exp, iat, iss, aud)
+- JWT access tokens with standard claims (sub, exp, iat, iss, aud) plus a stable session id (`sid`)
 - Opaque refresh tokens with automatic rotation
 - One-time exchange codes for OAuth callbacks
-- Family-based token revocation on reuse detection
+- Family-based token revocation on reuse detection, addressable by session id
+- Credential-issuance hooks that run inside the store transaction
 
 ## Configuration
 
@@ -51,6 +52,7 @@ Short-lived JWT for API authentication. Validated on each request via `PassageBe
 | `iat` | Issued at timestamp |
 | `iss` | Token issuer (optional) |
 | `aud` | Intended audience (optional) |
+| `sid` | Session id (UUID string); the same value across every refresh of one sign-in. Read it with `request.passage.sessionId` |
 | `scope` | Authorization scope (optional) |
 
 ### Refresh Token (Opaque)
@@ -62,6 +64,7 @@ Long-lived opaque token stored **hashed** in database. Used to obtain new access
 - Linked to user via `userId`
 - Tracks rotation chain via `replacedById`
 - Supports revocation via `revokedAt`
+- Carries `sessionId`, the `sid` of the access tokens minted alongside it; every row in one rotation chain shares it
 
 ### Exchange Token
 
@@ -76,10 +79,16 @@ One-time code for OAuth redirect flows. Allows secure token handoff after browse
 
 ### Issue (Login/OAuth)
 
-1. Generate JWT access token with user claims
-2. Generate random opaque refresh token
-3. Hash refresh token and store in database
-4. Return `AuthUser` with both tokens
+Reached through `request.passage.login(_:origin:via: .bearer)`, which the built-in routes call for JSON clients, and through `refresh` and `exchange`. Browser logins (`via: .browser`) set a cookie session instead and never enter this path.
+
+1. Take the `sessionId` handed in by the caller and sign the JWT access token with user claims and `sid`
+2. Generate random opaque refresh token and hash it
+3. Open a store transaction (`Passage.Store.transaction`):
+   1. With `revokeExisting: true` (the default) revoke the user's existing refresh tokens and collect their session ids
+   2. Store the refresh-token row with `sessionId`
+   3. Call `Passage.Hooks.Account.willIssueCredential` — a throw rolls everything back and the route answers the error
+4. Commit, then call `didIssueCredential`
+5. Return `AuthUser` with both tokens
 
 ### Refresh
 
@@ -87,15 +96,19 @@ One-time code for OAuth redirect flows. Allows secure token handoff after browse
 2. Look up in database by hash
 3. Validate: not expired, not revoked, not replaced
 4. If invalid → **revoke entire token family** (security)
-5. Generate new access + refresh tokens
-6. Mark old token as replaced by new one
-7. Return new `AuthUser`
+5. Reuse the row's `sessionId` and sign a new access token with the same `sid`
+6. Inside the store transaction: store the new refresh token with that `sessionId`, mark the old token as replaced, call `willIssueCredential` with `origin: .refresh`
+7. Commit, call `didIssueCredential`, return new `AuthUser`
 
 ### Revoke (Logout/Password Change)
 
 1. Find all refresh tokens for user
 2. Mark as revoked
 3. User must re-authenticate
+
+### Revoke one session
+
+`try await request.passage.revoke(sessionId:)` calls `TokenStore.revokeRefreshTokens(sessionId:)`, which revokes every refresh token carrying that `sid`; the next refresh with any of them fails with `invalidRefreshToken`. Access tokens already in flight stay valid until `exp` unless the host implements `Passage.Hooks.Account.isSessionRevoked`, which `PassageBearerAuthenticator` consults for every JWT that carries a `sid`.
 
 ## Token Rotation & Family Revocation
 
@@ -194,6 +207,7 @@ sequenceDiagram
 |-------|---------|
 | `refreshTokenNotFound` | Token hash not found in database |
 | `invalidRefreshToken` | Token expired, revoked, or already replaced |
+| `sessionRevoked` | Bearer JWT carries a `sid` that the host's `isSessionRevoked` reported as revoked |
 
 ### Token Storage
 

--- a/Sources/Passage/Hooks/Hooks+Account.swift
+++ b/Sources/Passage/Hooks/Hooks+Account.swift
@@ -1,3 +1,4 @@
+public import Foundation
 public import Vapor
 
 public extension Passage.Hooks {
@@ -39,6 +40,23 @@ public extension Passage.Hooks {
             user: any User,
             on request: Request,
         ) async
+
+        // MARK: Credential Issuance Hooks
+
+        func willIssueCredential(
+            _ issuance: CredentialIssuance,
+            on request: Request,
+        ) async throws
+
+        func didIssueCredential(
+            _ issuance: CredentialIssuance,
+            on request: Request,
+        ) async
+
+        func isSessionRevoked(
+            _ sessionId: UUID,
+            on request: Request,
+        ) async -> Bool
     }
 
 }
@@ -76,6 +94,23 @@ public extension Passage.Hooks.Account {
         user: any User,
         on request: Request,
     ) async {}
+
+    func willIssueCredential(
+        _ issuance: CredentialIssuance,
+        on request: Request,
+    ) async throws {}
+
+    func didIssueCredential(
+        _ issuance: CredentialIssuance,
+        on request: Request,
+    ) async {}
+
+    func isSessionRevoked(
+        _ sessionId: UUID,
+        on request: Request,
+    ) async -> Bool {
+        false
+    }
 }
 
 // MARK: - Closure-Based Hooks
@@ -90,6 +125,10 @@ public struct _AccountHooksClosures: Passage.Hooks.Account {
 
     let _willLogout: (@Sendable (any User, Request) async throws -> Void)?
     let _didLogout: (@Sendable (any User, Request) async -> Void)?
+
+    let _willIssueCredential: (@Sendable (CredentialIssuance, Request) async throws -> Void)?
+    let _didIssueCredential: (@Sendable (CredentialIssuance, Request) async -> Void)?
+    let _isSessionRevoked: (@Sendable (UUID, Request) async -> Bool)?
 
     public func willRegister(
         with form: any RegisterForm,
@@ -132,17 +171,41 @@ public struct _AccountHooksClosures: Passage.Hooks.Account {
     ) async {
         await _didLogout?(user, request)
     }
+
+    public func willIssueCredential(
+        _ issuance: CredentialIssuance,
+        on request: Request,
+    ) async throws {
+        try await _willIssueCredential?(issuance, request)
+    }
+
+    public func didIssueCredential(
+        _ issuance: CredentialIssuance,
+        on request: Request,
+    ) async {
+        await _didIssueCredential?(issuance, request)
+    }
+
+    public func isSessionRevoked(
+        _ sessionId: UUID,
+        on request: Request,
+    ) async -> Bool {
+        await _isSessionRevoked?(sessionId, request) ?? false
+    }
 }
 
 public extension Passage.Hooks.Account where Self == _AccountHooksClosures {
 
     static func hook(
-        willRegisterUser : (@Sendable (any RegisterForm, Request) async throws -> Void)? = nil,
-        didRegisterUser  : (@Sendable (any User, Request) async -> Void)? = nil,
-        willLoginUser    : (@Sendable (any User, Request) async throws -> Void)? = nil,
-        didLoginUser     : (@Sendable (any User, Request) async -> Void)? = nil,
-        willLogoutUser   : (@Sendable (any User, Request) async throws -> Void)? = nil,
-        didLogoutUser    : (@Sendable (any User, Request) async -> Void)? = nil,
+        willRegisterUser    : (@Sendable (any RegisterForm, Request) async throws -> Void)? = nil,
+        didRegisterUser     : (@Sendable (any User, Request) async -> Void)? = nil,
+        willLoginUser       : (@Sendable (any User, Request) async throws -> Void)? = nil,
+        didLoginUser        : (@Sendable (any User, Request) async -> Void)? = nil,
+        willLogoutUser      : (@Sendable (any User, Request) async throws -> Void)? = nil,
+        didLogoutUser       : (@Sendable (any User, Request) async -> Void)? = nil,
+        willIssueCredential : (@Sendable (CredentialIssuance, Request) async throws -> Void)? = nil,
+        didIssueCredential  : (@Sendable (CredentialIssuance, Request) async -> Void)? = nil,
+        isSessionRevoked    : (@Sendable (UUID, Request) async -> Bool)? = nil,
     ) -> some Passage.Hooks.Account {
         _AccountHooksClosures(
             _willRegister: willRegisterUser,
@@ -151,6 +214,9 @@ public extension Passage.Hooks.Account where Self == _AccountHooksClosures {
             _didLogin: didLoginUser,
             _willLogout: willLogoutUser,
             _didLogout: didLogoutUser,
+            _willIssueCredential: willIssueCredential,
+            _didIssueCredential: didIssueCredential,
+            _isSessionRevoked: isSessionRevoked,
         )
     }
 

--- a/Sources/Passage/PassageAuthenticators.swift
+++ b/Sources/Passage/PassageAuthenticators.swift
@@ -12,6 +12,11 @@ public struct PassageBearerAuthenticator: JWTAuthenticator {
         jwt: AccessToken,
         for request: Vapor.Request,
     ) async throws {
+        let sessionId = jwt.sessionId
+        if await request.hooks.account?.isSessionRevoked(sessionId, on: request) == true {
+            throw AuthenticationError.sessionRevoked
+        }
+        request.storage[PassageContext.BearerSessionIdKey.self] = sessionId
         let user = try await request.account.user(for: jwt)
         request.auth.login(user)
     }
@@ -39,11 +44,16 @@ public struct PassageSessionAuthenticator: AsyncAuthenticator {
         }
 
         if request.hasSession, let aID = request.session.authenticated(request.store.users.userType) {
-            // try to find user with id from session
-            let user = try await request.account.user(
-                withId: aID.description
-            )
-            request.auth.login(user)
+            if let sessionId = request.session.sessionId,
+               await request.hooks.account?.isSessionRevoked(sessionId, on: request) == true {
+                request.session.unauthenticate(request.store.users.userType)
+                request.session.sessionId = nil
+            } else {
+                let user = try await request.account.user(
+                    withId: aID.description
+                )
+                request.auth.login(user)
+            }
         }
 
         // respond to the request

--- a/Sources/Passage/PassageContext.swift
+++ b/Sources/Passage/PassageContext.swift
@@ -32,22 +32,28 @@ extension PassageContext {
                 throw PassageError.sessionsDisabled
             }
 
-            let issuance = CredentialIssuance(
-                kind: .browser,
-                origin: origin,
-                user: user,
-                sessionId: sessionId,
-                store: request.store
-            )
+            let request = self.request
+            let hooks = request.hooks.account
 
-            try await request.hooks.account?.willIssueCredential(issuance, on: request)
+            let issuance = try await request.store.transaction { store in
+                let issuance = CredentialIssuance(
+                    kind: .browser,
+                    origin: origin,
+                    user: user,
+                    sessionId: sessionId,
+                    store: store
+                )
+
+                try await hooks?.willIssueCredential(issuance, on: request)
+
+                return issuance
+            }
 
             request.auth.login(user)
             request.session.authenticate(user)
             request.session.sessionId = issuance.sessionId
 
-            await request.hooks.account?.didIssueCredential(issuance, on: request)
-
+            await hooks?.didIssueCredential(issuance, on: request)
             return nil
 
         case .bearer:

--- a/Sources/Passage/PassageContext.swift
+++ b/Sources/Passage/PassageContext.swift
@@ -1,3 +1,4 @@
+public import Foundation
 import Vapor
 
 public struct PassageContext: Sendable {
@@ -18,10 +19,40 @@ public struct PassageContext: Sendable {
 
 extension PassageContext {
 
-    func login(_ user: any User) {
-        request.auth.login(user)
-        if request.configuration.sessions.enabled {
+    public func login(
+        _ user: any User,
+        origin: CredentialIssuance.Origin,
+        via transport: Passage.Transport,
+        sessionId: UUID = UUID(),
+        revokeExisting: Bool = true
+    ) async throws -> AuthUser? {
+        switch transport {
+        case .browser:
+            guard request.configuration.sessions.enabled else {
+                throw PassageError.sessionsDisabled
+            }
+
+            let issuance = CredentialIssuance(
+                kind: .browser,
+                origin: origin,
+                user: user,
+                sessionId: sessionId,
+                store: request.store
+            )
+
+            try await request.hooks.account?.willIssueCredential(issuance, on: request)
+
+            request.auth.login(user)
             request.session.authenticate(user)
+            request.session.sessionId = issuance.sessionId
+
+            await request.hooks.account?.didIssueCredential(issuance, on: request)
+
+            return nil
+
+        case .bearer:
+            request.auth.login(user)
+            return try await request.tokens.issue(for: user, sessionId: sessionId, revokeExisting: revokeExisting, origin: origin)
         }
     }
 
@@ -29,7 +60,37 @@ extension PassageContext {
         request.auth.logout(request.store.users.userType)
         if request.configuration.sessions.enabled {
             request.session.unauthenticate(request.store.users.userType)
+            request.session.sessionId = nil
         }
+    }
+}
+
+// MARK: - Session Revocation
+
+public extension PassageContext {
+
+    func revoke(sessionId: UUID) async throws {
+        try await request.tokens.revoke(sessionId: sessionId)
+    }
+
+}
+
+// MARK: - Session Id Storage
+
+extension PassageContext {
+
+    struct BearerSessionIdKey: StorageKey {
+        typealias Value = UUID
+    }
+
+    public var sessionId: UUID? {
+        if let sessionId = request.storage[BearerSessionIdKey.self] {
+            return sessionId
+        }
+        guard request.configuration.sessions.enabled, request.hasSession else {
+            return nil
+        }
+        return request.session.sessionId
     }
 }
 
@@ -45,4 +106,3 @@ public extension PassageContext {
         request.passwordless
     }
 }
-

--- a/Sources/Passage/Protocols/RefreshToken.swift
+++ b/Sources/Passage/Protocols/RefreshToken.swift
@@ -16,6 +16,8 @@ public protocol RefreshToken: Sendable {
     var revokedAt: Date? { get }
 
     var replacedBy: Id? { get }
+
+    var sessionId: UUID { get }
 }
 
 // MARK:

--- a/Sources/Passage/Services/Passage+Store.swift
+++ b/Sources/Passage/Services/Passage+Store.swift
@@ -13,15 +13,16 @@ public extension Passage {
         var exchangeTokens: any ExchangeTokenStore { get }
         var passkeyCredentials: (any PasskeyCredentialStore)? { get }
         var passkeyChallenges: (any PasskeyChallengeStore)? { get }
+
+        func transaction<T: Sendable>(
+            _ body: @Sendable (any Store) async throws -> T
+        ) async throws -> T
     }
 
 }
 
 // MARK: - Store Default Implementations
 
-/// Default-nil implementations for the opt-in passkey sub-stores. This preserves
-/// source compatibility for existing `Store` conformances (e.g. third-party
-/// stores and `PassageFluent.DatabaseStore`) that predate passkey support.
 public extension Passage.Store {
     var passkeyCredentials: (any Passage.PasskeyCredentialStore)? { nil }
     var passkeyChallenges: (any Passage.PasskeyChallengeStore)? { nil }
@@ -79,6 +80,7 @@ public extension Passage {
             for user: any User,
             tokenHash hash: String,
             expiresAt: Date,
+            sessionId: UUID
         ) async throws -> any RefreshToken
 
         @discardableResult
@@ -86,13 +88,17 @@ public extension Passage {
             for user: any User,
             tokenHash hash: String,
             expiresAt: Date,
+            sessionId: UUID,
             replacing tokenToReplace: (any RefreshToken)?
         ) async throws -> any RefreshToken
 
         func find(refreshTokenHash hash: String) async throws -> (any RefreshToken)?
-        func revokeRefreshToken(for user: any User) async throws
+
+        @discardableResult
+        func revokeRefreshTokens(for user: any User) async throws -> [UUID]
         func revokeRefreshToken(withHash hash: String) async throws
         func revoke(refreshTokenFamilyStartingFrom token: any RefreshToken) async throws
+        func revokeRefreshTokens(sessionId: UUID) async throws
     }
 
 }

--- a/Sources/Passage/Session+Passage.swift
+++ b/Sources/Passage/Session+Passage.swift
@@ -1,0 +1,19 @@
+import Vapor
+
+extension Session {
+
+    static let sessionIdKey = "_PassageSessionId"
+
+    var sessionId: UUID? {
+        get {
+            guard let string = data[Self.sessionIdKey] else {
+                return nil
+            }
+            return UUID(uuidString: string)
+        }
+        set {
+            data[Self.sessionIdKey] = newValue?.uuidString
+        }
+    }
+
+}

--- a/Sources/Passage/Types/AccessToken.swift
+++ b/Sources/Passage/Types/AccessToken.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 public import JWT
 
 public struct AccessToken: Sendable {
@@ -10,6 +10,9 @@ public struct AccessToken: Sendable {
     let issuer: IssuerClaim?
     let audience: AudienceClaim?
 
+    // Session claim
+    public let sessionId: UUID
+
     // Authorization claims
     let scope: String?
 
@@ -19,7 +22,8 @@ public struct AccessToken: Sendable {
         expiresAt: Date,
         issuer: String?,
         audience: String?,
-        scope: String?
+        scope: String?,
+        sessionId: UUID
     ) {
         self.subject = SubjectClaim(value: userId)
         self.issuedAt = IssuedAtClaim(value: issuedAt)
@@ -27,6 +31,7 @@ public struct AccessToken: Sendable {
         self.issuer = issuer.map { IssuerClaim(value: $0) }
         self.audience = audience.map { AudienceClaim(value: $0) }
         self.scope = scope
+        self.sessionId = sessionId
     }
 }
 
@@ -39,6 +44,7 @@ extension AccessToken: JWTPayload {
         case issuedAt = "iat"
         case issuer = "iss"
         case audience = "aud"
+        case sessionId = "sid"
         case scope
     }
 

--- a/Sources/Passage/Types/CredentialIssuance.swift
+++ b/Sources/Passage/Types/CredentialIssuance.swift
@@ -1,0 +1,51 @@
+public import Foundation
+
+public struct CredentialIssuance: Sendable {
+
+    public enum Kind: Sendable, Equatable {
+        case bearer
+        case browser
+    }
+
+    public enum Origin: Sendable, Equatable {
+        case login
+        case magicLink
+        case refresh
+        case exchange
+        case federatedLogin
+        case passkey
+        case accountLinking
+    }
+
+    public let kind: Kind
+    public let origin: Origin
+    public let user: any User
+    public let sessionId: UUID
+    public let accessToken: String?
+    public let accessTokenExpiresAt: Date?
+    public let refreshTokenExpiresAt: Date?
+    public let revokedSessionIds: [UUID]
+    public let store: any Passage.Store
+
+    public init(
+        kind: Kind,
+        origin: Origin,
+        user: any User,
+        sessionId: UUID,
+        accessToken: String? = nil,
+        accessTokenExpiresAt: Date? = nil,
+        refreshTokenExpiresAt: Date? = nil,
+        revokedSessionIds: [UUID] = [],
+        store: any Passage.Store
+    ) {
+        self.kind = kind
+        self.origin = origin
+        self.user = user
+        self.sessionId = sessionId
+        self.accessToken = accessToken
+        self.accessTokenExpiresAt = accessTokenExpiresAt
+        self.refreshTokenExpiresAt = refreshTokenExpiresAt
+        self.revokedSessionIds = revokedSessionIds
+        self.store = store
+    }
+}

--- a/Sources/Passage/Types/Transport.swift
+++ b/Sources/Passage/Types/Transport.swift
@@ -1,0 +1,6 @@
+public extension Passage {
+    enum Transport: Sendable, Equatable {
+        case browser
+        case bearer
+    }
+}

--- a/Sources/PassageOnlyForTest/OnlyForTest+Store.swift
+++ b/Sources/PassageOnlyForTest/OnlyForTest+Store.swift
@@ -42,6 +42,7 @@ extension Passage.OnlyForTest {
         var expiresAt: Date
         var revokedAt: Date?
         var replacedBy: String?
+        var sessionId: UUID
     }
 
     struct InMemoryEmailVerificationCode: EmailVerificationCode, @unchecked Sendable {
@@ -362,12 +363,14 @@ public extension Passage.OnlyForTest.InMemoryStore {
         public func createRefreshToken(
             for user: any User,
             tokenHash hash: String,
-            expiresAt: Date
+            expiresAt: Date,
+            sessionId: UUID
         ) async throws -> any RefreshToken {
             return try await createRefreshToken(
                 for: user,
                 tokenHash: hash,
                 expiresAt: expiresAt,
+                sessionId: sessionId,
                 replacing: nil
             )
         }
@@ -377,6 +380,7 @@ public extension Passage.OnlyForTest.InMemoryStore {
             for user: any User,
             tokenHash hash: String,
             expiresAt: Date,
+            sessionId: UUID,
             replacing tokenToReplace: (any RefreshToken)?
         ) async throws -> any RefreshToken {
             let tokenId = UUID().uuidString
@@ -400,11 +404,24 @@ public extension Passage.OnlyForTest.InMemoryStore {
                 tokenHash: hash,
                 expiresAt: expiresAt,
                 revokedAt: nil,
-                replacedBy: nil
+                replacedBy: nil,
+                sessionId: sessionId
             )
 
             tokens[hash] = token
             return token
+        }
+
+        public var refreshTokens: [any RefreshToken] {
+            Array(tokens.values)
+        }
+
+        func snapshot() -> [String: Passage.OnlyForTest.InMemoryRefreshToken] {
+            tokens
+        }
+
+        func restore(_ snapshot: [String: Passage.OnlyForTest.InMemoryRefreshToken]) {
+            tokens = snapshot
         }
 
         public func find(refreshTokenHash hash: String) async throws -> (any RefreshToken)? {
@@ -422,6 +439,29 @@ public extension Passage.OnlyForTest.InMemoryStore {
 
         public func revokeRefreshToken(withHash hash: String) async throws {
             tokens[hash]?.revokedAt = Date()
+        }
+
+        @discardableResult
+        public func revokeRefreshTokens(for user: any User) async throws -> [UUID] {
+            guard let userId = user.id?.description else { return [] }
+
+            var revoked: [UUID] = []
+            for (hash, var token) in tokens where token.userId == userId && token.revokedAt == nil {
+                token.revokedAt = Date()
+                tokens[hash] = token
+                let sessionId = token.sessionId
+                if !revoked.contains(sessionId) {
+                    revoked.append(sessionId)
+                }
+            }
+            return revoked
+        }
+
+        public func revokeRefreshTokens(sessionId: UUID) async throws {
+            for (hash, var token) in tokens where token.sessionId == sessionId && token.revokedAt == nil {
+                token.revokedAt = Date()
+                tokens[hash] = token
+            }
         }
 
         public func revoke(refreshTokenFamilyStartingFrom token: any RefreshToken) async throws {

--- a/Sources/PassageOnlyForTest/Passage+OnlyForTest.swift
+++ b/Sources/PassageOnlyForTest/Passage+OnlyForTest.swift
@@ -24,6 +24,21 @@ public extension Passage {
                 self.passkeyCredentials = InMemoryPasskeyCredentialStore()
                 self.passkeyChallenges = InMemoryPasskeyChallengeStore()
             }
+
+            public func transaction<T: Sendable>(
+                _ body: @Sendable (any Passage.Store) async throws -> T
+            ) async throws -> T {
+                guard let tokens = tokens as? InMemoryTokenStore else {
+                    return try await body(self)
+                }
+                let snapshot = tokens.snapshot()
+                do {
+                    return try await body(self)
+                } catch {
+                    tokens.restore(snapshot)
+                    throw error
+                }
+            }
         }
 
     }

--- a/Tests/PassageTests/AAL1/Architectural.swift
+++ b/Tests/PassageTests/AAL1/Architectural.swift
@@ -109,7 +109,8 @@ struct `AAL1 architectural attestations` {
         _ = try await store.tokens.createRefreshToken(
             for: alice,
             tokenHash: random.hashOpaqueToken(token: aliceSecret),
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
 
         let resolved = try await store.tokens.find(
@@ -143,17 +144,19 @@ struct `AAL1 architectural attestations` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: firstSecret),
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
 
         // Second auth event — models the real `issue(for: user,
         // revokeExisting: true)` path in Passage.Tokens.issue.
-        try await store.tokens.revokeRefreshToken(for: user)
+        try await store.tokens.revokeRefreshTokens(for: user)
         let secondSecret = random.generateOpaqueToken()
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: secondSecret),
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
 
         // The first session's secret no longer opens a valid session —
@@ -218,7 +221,8 @@ struct `AAL1 architectural attestations` {
         let token = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: secret),
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
 
         // The session record knows only about the subscriber and its own

--- a/Tests/PassageTests/AAL1/MemorizedSecret/PasswordRotationTests.swift
+++ b/Tests/PassageTests/AAL1/MemorizedSecret/PasswordRotationTests.swift
@@ -97,7 +97,7 @@ struct `AAL1 no arbitrary password rotation` {
             let user = try #require(try await store.users.find(byIdentifier: .username("compromised-user")))
             let newHash = try Bcrypt.hash("post-compromise-secret")
             try await store.users.setPassword(for: user, passwordHash: newHash)
-            try await store.tokens.revokeRefreshToken(for: user)
+            try await store.tokens.revokeRefreshTokens(for: user)
 
             // Old password SHALL no longer authenticate.
             try await app.testing().test(.POST, "auth/login", beforeRequest: { req in

--- a/Tests/PassageTests/AAL1/Reauthentication/PeriodicReauthenticationTests.swift
+++ b/Tests/PassageTests/AAL1/Reauthentication/PeriodicReauthenticationTests.swift
@@ -74,7 +74,8 @@ struct `AAL1 periodic reauthentication` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: firstSecret),
-            expiresAt: firstExpiresAt
+            expiresAt: firstExpiresAt,
+            sessionId: UUID()
         )
 
         // Simulate the subscriber re-presenting their auth factor before
@@ -82,13 +83,14 @@ struct `AAL1 periodic reauthentication` {
         // revokes the prior family and mints a fresh session secret whose
         // `expiresAt` is `now + TTL`. We model a fresh Bcrypt-backed
         // successful login here by calling the same storage primitives.
-        try await store.tokens.revokeRefreshToken(for: user)
+        try await store.tokens.revokeRefreshTokens(for: user)
         let freshSecret = random.generateOpaqueToken()
         let freshExpiresAt = Date().addingTimeInterval(600) // post-reauth TTL
         let freshToken = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: freshSecret),
-            expiresAt: freshExpiresAt
+            expiresAt: freshExpiresAt,
+            sessionId: UUID()
         )
 
         #expect(freshToken.expiresAt > firstExpiresAt,

--- a/Tests/PassageTests/AAL1/Reauthentication/SessionTerminationTests.swift
+++ b/Tests/PassageTests/AAL1/Reauthentication/SessionTerminationTests.swift
@@ -29,7 +29,8 @@ struct `AAL1 session termination` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: tokenHash,
-            expiresAt: expiredAt
+            expiresAt: expiredAt,
+            sessionId: UUID()
         )
 
         let stored = try await store.tokens.find(refreshTokenHash: tokenHash)
@@ -70,11 +71,12 @@ struct `AAL1 session termination` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: hash,
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
 
         // Terminate it (logout or admin revoke).
-        try await store.tokens.revokeRefreshToken(for: user)
+        try await store.tokens.revokeRefreshTokens(for: user)
 
         // The secret no longer resolves to a *live* session: the record is
         // retained (so `Passage.Tokens.refresh` can detect reuse attempts
@@ -95,7 +97,8 @@ struct `AAL1 session termination` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: freshHash,
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
         let freshLookup = try await store.tokens.find(refreshTokenHash: freshHash)
         #expect(freshLookup?.isValid == true,

--- a/Tests/PassageTests/AAL1/SessionManagement/ContinuityTests.swift
+++ b/Tests/PassageTests/AAL1/SessionManagement/ContinuityTests.swift
@@ -33,7 +33,8 @@ struct `AAL1 session continuity` {
         let validToken = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: validSecret),
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
         #expect(validToken.isValid,
                 "§7.2-a: a valid session secret must permit continuation")
@@ -47,7 +48,7 @@ struct `AAL1 session continuity` {
                 "§7.2-a: continuity must not be granted without the session secret")
 
         // Path C — continuity ends when the secret is revoked (logout).
-        try await store.tokens.revokeRefreshToken(for: user)
+        try await store.tokens.revokeRefreshTokens(for: user)
         let revoked = try await store.tokens.find(
             refreshTokenHash: random.hashOpaqueToken(token: validSecret)
         )
@@ -75,7 +76,8 @@ struct `AAL1 session continuity` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: hash,
-            expiresAt: Date().addingTimeInterval(-1) // models the TTL expiring
+            expiresAt: Date().addingTimeInterval(-1), // models the TTL expiring
+            sessionId: UUID()
         )
 
         let stored = try await store.tokens.find(refreshTokenHash: hash)
@@ -118,7 +120,8 @@ struct `AAL1 session continuity` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: hash,
-            expiresAt: originalExpiry
+            expiresAt: originalExpiry,
+            sessionId: UUID()
         )
 
         // Present the secret repeatedly (simulated by successive lookups):

--- a/Tests/PassageTests/AAL1/SessionManagement/FederationReauthenticationTests.swift
+++ b/Tests/PassageTests/AAL1/SessionManagement/FederationReauthenticationTests.swift
@@ -58,7 +58,8 @@ struct `AAL1 federation reauthentication` {
             expiresAt: eventTime.addingTimeInterval(900),
             issuer: "passage-test",
             audience: "rp-test",
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         // The `iat` claim carries the auth-event time — not the token-mint

--- a/Tests/PassageTests/AAL1/SessionManagement/SessionBindingTests.swift
+++ b/Tests/PassageTests/AAL1/SessionManagement/SessionBindingTests.swift
@@ -36,7 +36,8 @@ struct `AAL1 session binding` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: persistedHash,
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
 
         // Service-side: look up by the secret the subscriber would present.
@@ -75,7 +76,8 @@ struct `AAL1 session binding` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: subscriberSecret),
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
 
         // Directly presenting the secret resolves the session.
@@ -125,13 +127,15 @@ struct `AAL1 session binding` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: firstSecret),
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
         let secondSecret = random.generateOpaqueToken()
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: secondSecret),
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
 
         #expect(firstSecret != secondSecret,
@@ -171,7 +175,8 @@ struct `AAL1 session binding` {
         let token = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: random.hashOpaqueToken(token: hostSecret),
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
         #expect(token.tokenHash == random.hashOpaqueToken(token: hostSecret),
                 "§7.1-f: the persisted hash must match the host-generated secret")

--- a/Tests/PassageTests/AAL1/SessionManagement/SessionInvalidationTests.swift
+++ b/Tests/PassageTests/AAL1/SessionManagement/SessionInvalidationTests.swift
@@ -9,7 +9,7 @@ import Testing
 // by the session subject when the subscriber logs out. Passage's
 // `Passage.Account.logout()` implements this by calling
 // `Passage.Tokens.revoke(for:)`, which in turn calls
-// `store.tokens.revokeRefreshToken(for: user)`. After revocation, the
+// `store.tokens.revokeRefreshTokens(for: user)`. After revocation, the
 // refresh-token record is either gone or no longer valid — a subsequent
 // rotation attempt with the now-stale secret is rejected.
 
@@ -19,7 +19,7 @@ struct `AAL1 session invalidation` {
     @Test(.tags(.aal1, .sessionManagement, .authenticator, .unit, .shall))
     func `§7.1-h: Refresh-token session secret is invalidated on logout`() async throws {
         // Drive the real logout-side storage path: mint a secret, then call
-        // `revokeRefreshToken(for: user)` — the exact call `Passage.Tokens
+        // `revokeRefreshTokens(for: user)` — the exact call `Passage.Tokens
         // .revoke` makes. The invariant: after logout, the formerly-valid
         // secret can no longer be used to resolve a live session.
         let random = DefaultRandomGenerator()
@@ -34,7 +34,8 @@ struct `AAL1 session invalidation` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: hash,
-            expiresAt: Date().addingTimeInterval(3600)
+            expiresAt: Date().addingTimeInterval(3600),
+            sessionId: UUID()
         )
 
         // Sanity: before logout the session is alive.
@@ -43,7 +44,7 @@ struct `AAL1 session invalidation` {
                      "precondition: session secret must be valid before logout")
 
         // Logout — the same storage call `Passage.Tokens.revoke` issues.
-        try await store.tokens.revokeRefreshToken(for: user)
+        try await store.tokens.revokeRefreshTokens(for: user)
 
         // §7.1-h: the secret must no longer open a valid session. Either
         // the record is removed outright, or it remains but is no longer

--- a/Tests/PassageTests/AAL1/SessionManagement/SessionTimeoutTests.swift
+++ b/Tests/PassageTests/AAL1/SessionManagement/SessionTimeoutTests.swift
@@ -33,7 +33,8 @@ struct `AAL1 session-secret timeout` {
         _ = try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: hash,
-            expiresAt: Date().addingTimeInterval(-1) // already expired
+            expiresAt: Date().addingTimeInterval(-1), // already expired
+            sessionId: UUID()
         )
 
         let stored = try await store.tokens.find(refreshTokenHash: hash)

--- a/Tests/PassageTests/Integration/Account/CurrentUserIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Account/CurrentUserIntegrationTests.swift
@@ -334,7 +334,8 @@ struct `Current User (GET /me) Integration Tests` {
                 expiresAt: Date().addingTimeInterval(-3600), // Expired 1 hour ago
                 issuer: "test-issuer",
                 audience: nil,
-                scope: nil
+                scope: nil,
+                sessionId: UUID()
             )
 
             let req = Request(application: app, on: app.eventLoopGroup.any())

--- a/Tests/PassageTests/Integration/Hooks/CredentialIssuanceHooksIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Hooks/CredentialIssuanceHooksIntegrationTests.swift
@@ -36,6 +36,33 @@ struct `Credential Issuance Hooks Integration Tests` {
         }
     }
 
+    final class TransactionSpyStore: Passage.Store {
+        let inner: any Passage.Store
+        let isTransactionBound: Bool
+
+        init(inner: any Passage.Store, isTransactionBound: Bool = false) {
+            self.inner = inner
+            self.isTransactionBound = isTransactionBound
+        }
+
+        var users: any Passage.UserStore { inner.users }
+        var tokens: any Passage.TokenStore { inner.tokens }
+        var verificationCodes: any Passage.VerificationCodeStore { inner.verificationCodes }
+        var restorationCodes: any Passage.RestorationCodeStore { inner.restorationCodes }
+        var magicLinkTokens: any Passage.MagicLinkTokenStore { inner.magicLinkTokens }
+        var exchangeTokens: any Passage.ExchangeTokenStore { inner.exchangeTokens }
+        var passkeyCredentials: (any Passage.PasskeyCredentialStore)? { inner.passkeyCredentials }
+        var passkeyChallenges: (any Passage.PasskeyChallengeStore)? { inner.passkeyChallenges }
+
+        func transaction<T: Sendable>(
+            _ body: @Sendable (any Passage.Store) async throws -> T
+        ) async throws -> T {
+            try await inner.transaction { bound in
+                try await body(TransactionSpyStore(inner: bound, isTransactionBound: true))
+            }
+        }
+    }
+
     final class CapturedEmails: @unchecked Sendable {
         var emails: [Passage.OnlyForTest.MockEmailDelivery.EphemeralEmail] = []
     }
@@ -44,7 +71,8 @@ struct `Credential Issuance Hooks Integration Tests` {
         _ app: Application,
         hooks: Passage.Hooks = .init(),
         sessionsEnabled: Bool = false,
-        capturedEmails: CapturedEmails? = nil
+        capturedEmails: CapturedEmails? = nil,
+        store: (any Passage.Store)? = nil
     ) async throws {
         await app.jwt.keys.add(
             hmac: HMACKey(from: "test-secret-key-for-jwt-signing"),
@@ -56,7 +84,7 @@ struct `Credential Issuance Hooks Integration Tests` {
             app.middleware.use(app.sessions.middleware)
         }
 
-        let store = Passage.OnlyForTest.InMemoryStore()
+        let store = store ?? Passage.OnlyForTest.InMemoryStore()
         let emailDelivery: (any Passage.EmailDelivery)? = capturedEmails.map { captured in
             Passage.OnlyForTest.MockEmailDelivery(callback: { @Sendable in captured.emails.append($0) })
         }
@@ -361,6 +389,54 @@ struct `Credential Issuance Hooks Integration Tests` {
             #expect(issuance.origin == .login)
             #expect(issuance.accessToken == nil)
             #expect(issuance.refreshTokenExpiresAt == nil)
+        }
+    }
+
+    @Test
+    func `form login hands willIssueCredential a transaction-bound store`() async throws {
+        let spy = CredentialIssuanceSpy()
+        let store = TransactionSpyStore(inner: Passage.OnlyForTest.InMemoryStore())
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()), sessionsEnabled: true, store: store)
+        }) { app in
+            try await createTestUser(app: app, email: "browser4@test.com")
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "browser4@test.com", "password": "password123"], as: .urlEncodedForm)
+            }, afterResponse: { res async in
+                #expect(res.status == .seeOther || res.status == .found)
+            })
+
+            let issuance = try #require(spy.willIssuances.first)
+            #expect(issuance.kind == .browser)
+            let issuanceStore = try #require(issuance.store as? TransactionSpyStore)
+            #expect(issuanceStore.isTransactionBound)
+            #expect(!store.isTransactionBound)
+        }
+    }
+
+    @Test
+    func `JSON login hands willIssueCredential a transaction-bound store`() async throws {
+        let spy = CredentialIssuanceSpy()
+        let store = TransactionSpyStore(inner: Passage.OnlyForTest.InMemoryStore())
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()), store: store)
+        }) { app in
+            try await createTestUser(app: app, email: "bearer4@test.com")
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "bearer4@test.com", "password": "password123"])
+            }, afterResponse: { res async in
+                #expect(res.status == .ok)
+            })
+
+            let issuance = try #require(spy.willIssuances.first)
+            #expect(issuance.kind == .bearer)
+            let issuanceStore = try #require(issuance.store as? TransactionSpyStore)
+            #expect(issuanceStore.isTransactionBound)
         }
     }
 

--- a/Tests/PassageTests/Integration/Hooks/CredentialIssuanceHooksIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Hooks/CredentialIssuanceHooksIntegrationTests.swift
@@ -1,0 +1,567 @@
+import Foundation
+import JWT
+@testable import Passage
+@testable import PassageOnlyForTest
+import Testing
+import Vapor
+import VaporTesting
+
+@Suite(.tags(.integration, .hooks))
+struct `Credential Issuance Hooks Integration Tests` {
+
+    private struct TestPolicyError: AbortError {
+        let status: HTTPResponseStatus = .forbidden
+        let reason: String = "Blocked by hook"
+    }
+
+    final class CredentialIssuanceSpy: @unchecked Sendable {
+        var willIssuances: [CredentialIssuance] = []
+        var didIssuances: [CredentialIssuance] = []
+        var willThrowError: (any Error)?
+        var willThrowForKind: CredentialIssuance.Kind?
+
+        func makeAccountHook() -> any Passage.Hooks.Account {
+            _AccountHooksClosures.hook(
+                willIssueCredential: { [self] issuance, _ in
+                    self.willIssuances.append(issuance)
+                    if let error = self.willThrowError,
+                       self.willThrowForKind == nil || self.willThrowForKind == issuance.kind {
+                        throw error
+                    }
+                },
+                didIssueCredential: { [self] issuance, _ in
+                    self.didIssuances.append(issuance)
+                }
+            )
+        }
+    }
+
+    final class CapturedEmails: @unchecked Sendable {
+        var emails: [Passage.OnlyForTest.MockEmailDelivery.EphemeralEmail] = []
+    }
+
+    @Sendable private func configure(
+        _ app: Application,
+        hooks: Passage.Hooks = .init(),
+        sessionsEnabled: Bool = false,
+        capturedEmails: CapturedEmails? = nil
+    ) async throws {
+        await app.jwt.keys.add(
+            hmac: HMACKey(from: "test-secret-key-for-jwt-signing"),
+            digestAlgorithm: .sha256,
+            kid: JWKIdentifier(string: "test-key")
+        )
+
+        if sessionsEnabled {
+            app.middleware.use(app.sessions.middleware)
+        }
+
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let emailDelivery: (any Passage.EmailDelivery)? = capturedEmails.map { captured in
+            Passage.OnlyForTest.MockEmailDelivery(callback: { @Sendable in captured.emails.append($0) })
+        }
+        let services = Passage.Services(
+            store: store,
+            random: DefaultRandomGenerator(),
+            emailDelivery: emailDelivery,
+            phoneDelivery: nil,
+            federatedLogin: nil
+        )
+
+        let emptyJwks = """
+        {"keys":[]}
+        """
+
+        let loginView = Passage.Configuration.Views.LoginView(
+            style: .minimalism,
+            theme: Passage.Views.Theme(colors: .defaultLight),
+            identifier: .email
+        )
+        let viewsConfig = sessionsEnabled ? Passage.Configuration.Views(login: loginView) : Passage.Configuration.Views()
+
+        let configuration = try Passage.Configuration(
+            origin: URL(string: "http://localhost:8080")!,
+            routes: .init(),
+            tokens: .init(
+                issuer: "test-issuer",
+                accessToken: .init(timeToLive: 3600),
+                refreshToken: .init(timeToLive: 86400)
+            ),
+            sessions: .init(enabled: sessionsEnabled),
+            jwt: .init(jwks: .init(json: emptyJwks)),
+            passwordless: .init(
+                emailMagicLink: .email(
+                    useQueues: false,
+                    linkExpiration: 3600,
+                    maxAttempts: 3,
+                    autoCreateUser: true,
+                    requireSameBrowser: false
+                )
+            ),
+            verification: .init(
+                email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                useQueues: false
+            ),
+            restoration: .init(
+                email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                useQueues: false
+            ),
+            views: viewsConfig
+        )
+
+        try await app.passage.configure(
+            services: services,
+            configuration: configuration,
+            hooks: hooks
+        )
+    }
+
+    @Sendable private func createTestUser(
+        app: Application,
+        email: String = "user@example.com",
+        password: String = "password123"
+    ) async throws -> String {
+        let store = app.passage.storage.services.store
+        let passwordHash = try await app.password.async.hash(password)
+        let identifier = Identifier.email(email)
+        let credential = Credential.password(passwordHash)
+        let user = try await store.users.create(identifier: identifier, with: credential)
+        try await store.users.markEmailVerified(for: user)
+        return user.id as! String
+    }
+
+    @Test
+    func `password login with throwing willIssueCredential returns 403 and stores no token`() async throws {
+        let spy = CredentialIssuanceSpy()
+        spy.willThrowError = TestPolicyError()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()))
+        }) { app in
+            try await createTestUser(app: app, email: "user1@test.com")
+
+            let store = app.passage.storage.services.store
+            let tokenCountBefore = (store.tokens as! Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore).refreshTokens.count
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "user1@test.com", "password": "password123"])
+            }, afterResponse: { res async in
+                #expect(res.status == .forbidden)
+            })
+
+            let tokenCountAfter = (store.tokens as! Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore).refreshTokens.count
+            #expect(tokenCountBefore == tokenCountAfter)
+            #expect(spy.didIssuances.isEmpty)
+        }
+    }
+
+    @Test
+    func `password login with succeeding willIssueCredential returns 200 and creates token`() async throws {
+        let spy = CredentialIssuanceSpy()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()))
+        }) { app in
+            let userId = try await createTestUser(app: app, email: "user2@test.com")
+
+            var accessToken: String = ""
+            var refreshToken: String = ""
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "user2@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                accessToken = authUser.accessToken
+                refreshToken = authUser.refreshToken
+            })
+
+            #expect(spy.willIssuances.count == 1)
+            #expect(spy.didIssuances.count == 1)
+
+            let issuance = spy.willIssuances[0]
+            #expect(issuance.kind == .bearer)
+            #expect(issuance.origin == .login)
+            #expect(issuance.accessToken == accessToken)
+            #expect(issuance.accessTokenExpiresAt != nil)
+            #expect(issuance.refreshTokenExpiresAt != nil)
+
+            let decodedToken = try await app.jwt.keys.verify(accessToken, as: AccessToken.self)
+            #expect(decodedToken.sessionId == issuance.sessionId)
+            #expect(decodedToken.subject.value == userId)
+
+            let store = app.passage.storage.services.store
+            let tokenStore = store.tokens as! Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore
+            let random = app.passage.storage.services.random
+            let refreshTokenHash = random.hashOpaqueToken(token: refreshToken)
+            let refreshTokenRow = try await store.tokens.find(refreshTokenHash: refreshTokenHash)
+            #expect(refreshTokenRow?.sessionId == issuance.sessionId)
+        }
+    }
+
+    @Test
+    func `second password login revokes first login's sessionId`() async throws {
+        let spy = CredentialIssuanceSpy()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()))
+        }) { app in
+            let userId = try await createTestUser(app: app, email: "user3@test.com")
+
+            var firstSessionId: UUID?
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "user3@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                let decodedToken = try await app.jwt.keys.verify(authUser.accessToken, as: AccessToken.self)
+                firstSessionId = decodedToken.sessionId
+            })
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "user3@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+            })
+
+            #expect(spy.willIssuances.count == 2)
+            let secondIssuance = spy.willIssuances[1]
+            #expect(secondIssuance.revokedSessionIds == [firstSessionId!])
+        }
+    }
+
+
+    @Test
+    func `refresh token with throwing willIssueCredential returns 403 and stores no new token`() async throws {
+        let spy = CredentialIssuanceSpy()
+        spy.willThrowForKind = .bearer
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()))
+        }) { app in
+            let userId = try await createTestUser(app: app, email: "refresh1@test.com")
+
+            var refreshToken = ""
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "refresh1@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                refreshToken = authUser.refreshToken
+            })
+
+            spy.willThrowError = TestPolicyError()
+
+            let store = app.passage.storage.services.store
+            let tokenCountBefore = (store.tokens as! Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore).refreshTokens.count
+
+            try await app.testing().test(.POST, "auth/refresh-token", beforeRequest: { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            }, afterResponse: { res async in
+                #expect(res.status == .forbidden)
+            })
+
+            let tokenCountAfter = (store.tokens as! Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore).refreshTokens.count
+            #expect(tokenCountBefore == tokenCountAfter)
+        }
+    }
+
+    @Test
+    func `refresh token with succeeding willIssueCredential returns 200`() async throws {
+        let spy = CredentialIssuanceSpy()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()))
+        }) { app in
+            let userId = try await createTestUser(app: app, email: "refresh2@test.com")
+
+            var refreshToken = ""
+            var firstSessionId: UUID?
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "refresh2@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                refreshToken = authUser.refreshToken
+                let decodedToken = try await app.jwt.keys.verify(authUser.accessToken, as: AccessToken.self)
+                firstSessionId = decodedToken.sessionId
+            })
+
+            spy.willIssuances.removeAll()
+            spy.didIssuances.removeAll()
+
+            try await app.testing().test(.POST, "auth/refresh-token", beforeRequest: { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+            })
+
+            #expect(spy.willIssuances.count == 1)
+            #expect(spy.didIssuances.count == 1)
+            let issuance = spy.willIssuances[0]
+            #expect(issuance.origin == .refresh)
+            #expect(issuance.sessionId == firstSessionId)
+            #expect(issuance.revokedSessionIds.isEmpty)
+        }
+    }
+
+    @Test
+    func `browser login with throwing willIssueCredential (browser) returns 303 and no session cookie`() async throws {
+        let spy = CredentialIssuanceSpy()
+        spy.willThrowForKind = .browser
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()), sessionsEnabled: true)
+        }) { app in
+            try await createTestUser(app: app, email: "browser1@test.com")
+
+            spy.willThrowError = TestPolicyError()
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "browser1@test.com", "password": "password123"], as: .urlEncodedForm)
+            }, afterResponse: { res async in
+                #expect(res.status == .seeOther || res.status == .found)
+                let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
+                #expect(!hasSessionCookie)
+            })
+
+            #expect(spy.didIssuances.isEmpty)
+        }
+    }
+
+    @Test
+    func `form login with sessions enabled yields one browser issuance and no refresh token`() async throws {
+        let spy = CredentialIssuanceSpy()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()), sessionsEnabled: true)
+        }) { app in
+            try await createTestUser(app: app, email: "browser2@test.com")
+            let tokenCountBefore = tokenStore(app).refreshTokens.count
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "browser2@test.com", "password": "password123"], as: .urlEncodedForm)
+            }, afterResponse: { res async throws in
+                #expect(res.status == .seeOther || res.status == .found)
+                let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
+                #expect(hasSessionCookie)
+            })
+
+            #expect(tokenStore(app).refreshTokens.count == tokenCountBefore)
+            #expect(spy.willIssuances.count == 1)
+            #expect(spy.didIssuances.count == 1)
+
+            let issuance = try #require(spy.willIssuances.first)
+            #expect(issuance.kind == .browser)
+            #expect(issuance.origin == .login)
+            #expect(issuance.accessToken == nil)
+            #expect(issuance.refreshTokenExpiresAt == nil)
+        }
+    }
+
+    @Test
+    func `JSON login with sessions enabled yields one bearer issuance and no cookie`() async throws {
+        let spy = CredentialIssuanceSpy()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()), sessionsEnabled: true)
+        }) { app in
+            try await createTestUser(app: app, email: "browser3@test.com")
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "browser3@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
+                #expect(!hasSessionCookie)
+            })
+
+            #expect(spy.willIssuances.count == 1)
+            #expect(spy.didIssuances.count == 1)
+
+            let issuance = try #require(spy.willIssuances.first)
+            #expect(issuance.kind == .bearer)
+            #expect(issuance.origin == .login)
+            #expect(issuance.accessToken != nil)
+        }
+    }
+
+    private func tokenStore(_ app: Application) -> Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore {
+        app.passage.storage.services.store.tokens as! Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore
+    }
+
+    private func requestMagicLinkToken(app: Application, captured: CapturedEmails, email: String) async throws -> String {
+        try await app.testing().test(.POST, "auth/magic-link/email", beforeRequest: { req in
+            try req.content.encode(["email": email])
+        }, afterResponse: { res async in
+            #expect(res.status == .ok)
+        })
+        let url = try #require(captured.emails.last?.magicLinkURL)
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let token = try #require(components.queryItems?.first(where: { $0.name == "token" })?.value)
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "+/=")
+        return try #require(token.addingPercentEncoding(withAllowedCharacters: allowed))
+    }
+
+    private func createExchangeCode(app: Application, userId: String) async throws -> String {
+        let store = app.passage.storage.services.store
+        let random = app.passage.storage.services.random
+        let user = try #require(try await store.users.find(byId: userId))
+        let code = random.generateOpaqueToken()
+        try await store.exchangeTokens.createExchangeToken(
+            for: user,
+            tokenHash: random.hashOpaqueToken(token: code),
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        return code
+    }
+
+    private func assertBearerIssuance(
+        app: Application,
+        spy: CredentialIssuanceSpy,
+        origin: CredentialIssuance.Origin,
+        accessToken: String,
+        refreshToken: String
+    ) async throws {
+        #expect(spy.willIssuances.count == 1)
+        #expect(spy.didIssuances.count == 1)
+        let issuance = try #require(spy.willIssuances.first)
+        #expect(issuance.kind == .bearer)
+        #expect(issuance.origin == origin)
+        #expect(issuance.accessToken == accessToken)
+        #expect(issuance.accessTokenExpiresAt != nil)
+        #expect(issuance.refreshTokenExpiresAt != nil)
+        let decoded = try await app.jwt.keys.verify(accessToken, as: AccessToken.self)
+        #expect(decoded.sessionId == issuance.sessionId)
+        let hash = app.passage.storage.services.random.hashOpaqueToken(token: refreshToken)
+        let row = try await app.passage.storage.services.store.tokens.find(refreshTokenHash: hash)
+        #expect(row?.sessionId == issuance.sessionId)
+    }
+
+    @Test
+    func `magic link verify with throwing willIssueCredential returns 403 and stores no token`() async throws {
+        let spy = CredentialIssuanceSpy()
+        spy.willThrowError = TestPolicyError()
+        let captured = CapturedEmails()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()), capturedEmails: captured)
+        }) { app in
+            let token = try await requestMagicLinkToken(app: app, captured: captured, email: "magic-fail@test.com")
+            let before = tokenStore(app).refreshTokens.count
+
+            try await app.testing().test(.GET, "auth/magic-link/email/verify?token=\(token)", afterResponse: { res async in
+                #expect(res.status == .forbidden)
+            })
+
+            #expect(tokenStore(app).refreshTokens.count == before)
+            #expect(spy.willIssuances.count == 1)
+            #expect(spy.didIssuances.isEmpty)
+        }
+    }
+
+    @Test
+    func `magic link verify with succeeding willIssueCredential returns 200 and creates token`() async throws {
+        let spy = CredentialIssuanceSpy()
+        let captured = CapturedEmails()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()), capturedEmails: captured)
+        }) { app in
+            let token = try await requestMagicLinkToken(app: app, captured: captured, email: "magic-ok@test.com")
+
+            var accessToken = ""
+            var refreshToken = ""
+            try await app.testing().test(.GET, "auth/magic-link/email/verify?token=\(token)", afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                accessToken = authUser.accessToken
+                refreshToken = authUser.refreshToken
+            })
+
+            try await assertBearerIssuance(app: app, spy: spy, origin: .magicLink, accessToken: accessToken, refreshToken: refreshToken)
+        }
+    }
+
+    @Test
+    func `exchange code with throwing willIssueCredential returns 403 and stores no token`() async throws {
+        let spy = CredentialIssuanceSpy()
+        spy.willThrowError = TestPolicyError()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()))
+        }) { app in
+            let userId = try await createTestUser(app: app, email: "exchange-fail@test.com")
+            let code = try await createExchangeCode(app: app, userId: userId)
+            let before = tokenStore(app).refreshTokens.count
+
+            try await app.testing().test(.POST, "auth/token/exchange", beforeRequest: { req in
+                try req.content.encode(["code": code])
+            }, afterResponse: { res async in
+                #expect(res.status == .forbidden)
+            })
+
+            #expect(tokenStore(app).refreshTokens.count == before)
+            #expect(spy.willIssuances.count == 1)
+            #expect(spy.didIssuances.isEmpty)
+        }
+    }
+
+    @Test
+    func `exchange code with succeeding willIssueCredential returns 200 and creates token`() async throws {
+        let spy = CredentialIssuanceSpy()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()))
+        }) { app in
+            let userId = try await createTestUser(app: app, email: "exchange-ok@test.com")
+            let code = try await createExchangeCode(app: app, userId: userId)
+
+            var accessToken = ""
+            var refreshToken = ""
+            try await app.testing().test(.POST, "auth/token/exchange", beforeRequest: { req in
+                try req.content.encode(["code": code])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                accessToken = authUser.accessToken
+                refreshToken = authUser.refreshToken
+            })
+
+            try await assertBearerIssuance(app: app, spy: spy, origin: .exchange, accessToken: accessToken, refreshToken: refreshToken)
+        }
+    }
+
+    @Test
+    func `exchange code with sessions enabled yields one bearer issuance and no cookie`() async throws {
+        let spy = CredentialIssuanceSpy()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()), sessionsEnabled: true)
+        }) { app in
+            let userId = try await createTestUser(app: app, email: "exchange-sessions@test.com")
+            let code = try await createExchangeCode(app: app, userId: userId)
+
+            try await app.testing().test(.POST, "auth/token/exchange", beforeRequest: { req in
+                try req.content.encode(["code": code])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
+                #expect(!hasSessionCookie)
+            })
+
+            #expect(spy.willIssuances.count == 1)
+            #expect(spy.didIssuances.count == 1)
+
+            let issuance = try #require(spy.willIssuances.first)
+            #expect(issuance.kind == .bearer)
+            #expect(issuance.origin == .exchange)
+        }
+    }
+}

--- a/Tests/PassageTests/Integration/Middleware/PassageAuthenticatorIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Middleware/PassageAuthenticatorIntegrationTests.swift
@@ -102,7 +102,8 @@ struct `PassageBearerAuthenticator Integration Tests` {
             expiresAt: expiresAt,
             issuer: "test-issuer",
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         let req = Request(application: app, on: app.eventLoopGroup.any())

--- a/Tests/PassageTests/Integration/Middleware/PassageContextIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Middleware/PassageContextIntegrationTests.swift
@@ -106,7 +106,8 @@ struct `PassageContext Integration Tests` {
             expiresAt: Date().addingTimeInterval(3600),
             issuer: "test-issuer",
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         let req = Request(application: app, on: app.eventLoopGroup.any())

--- a/Tests/PassageTests/Integration/Middleware/PassageGuardIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Middleware/PassageGuardIntegrationTests.swift
@@ -103,7 +103,8 @@ struct `PassageGuard Integration Tests` {
             expiresAt: Date().addingTimeInterval(3600),
             issuer: "test-issuer",
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         let req = Request(application: app, on: app.eventLoopGroup.any())

--- a/Tests/PassageTests/Integration/Middleware/SessionAuthenticationIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Middleware/SessionAuthenticationIntegrationTests.swift
@@ -17,17 +17,14 @@ struct `Sessions Authentication Integration Tests` {
 
     /// Configures a test Vapor application with Passage and session support enabled
     @Sendable private func configureWithSession(_ app: Application) async throws {
-        // Enable sessions middleware
         app.middleware.use(app.sessions.middleware)
 
-        // Add HMAC key for JWT signing
         await app.jwt.keys.add(
             hmac: HMACKey(from: "test-secret-key-for-jwt-signing"),
             digestAlgorithm: .sha256,
             kid: JWKIdentifier(string: "test-key")
         )
 
-        // Configure Passage with test services and session enabled
         let store = Passage.OnlyForTest.InMemoryStore()
         let emailDelivery = Passage.OnlyForTest.MockEmailDelivery()
         let phoneDelivery = Passage.OnlyForTest.MockPhoneDelivery()
@@ -43,6 +40,13 @@ struct `Sessions Authentication Integration Tests` {
         let emptyJwks = """
         {"keys":[]}
         """
+
+        let loginView = Passage.Configuration.Views.LoginView(
+            style: .minimalism,
+            theme: Passage.Views.Theme(colors: .defaultLight),
+            identifier: .email
+        )
+        let viewsConfig = Passage.Configuration.Views(login: loginView)
 
         let configuration = try Passage.Configuration(
             origin: URL(string: "http://localhost:8080")!,
@@ -63,7 +67,8 @@ struct `Sessions Authentication Integration Tests` {
                 email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
                 phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
                 useQueues: false
-            )
+            ),
+            views: viewsConfig
         )
 
         try await app.passage.configure(
@@ -71,7 +76,6 @@ struct `Sessions Authentication Integration Tests` {
             configuration: configuration
         )
 
-        // Register test route with both session and bearer authenticators
         let authenticated = app
             .grouped(PassageSessionAuthenticator())
             .grouped(PassageBearerAuthenticator())
@@ -83,7 +87,89 @@ struct `Sessions Authentication Integration Tests` {
             return "not-authenticated"
         }
 
-        // Route protected by PassageGuard
+        let guarded = authenticated.grouped(PassageGuard())
+        guarded.get("test-protected") { req -> String in
+            let user = try req.passage.user
+            return "protected:\(try user.requiredIdAsString)"
+        }
+    }
+
+    @Sendable private func configureWithSessionAndRevokedHook(_ app: Application) async throws {
+        app.middleware.use(app.sessions.middleware)
+
+        await app.jwt.keys.add(
+            hmac: HMACKey(from: "test-secret-key-for-jwt-signing"),
+            digestAlgorithm: .sha256,
+            kid: JWKIdentifier(string: "test-key")
+        )
+
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let emailDelivery = Passage.OnlyForTest.MockEmailDelivery()
+        let phoneDelivery = Passage.OnlyForTest.MockPhoneDelivery()
+
+        let services = Passage.Services(
+            store: store,
+            random: DefaultRandomGenerator(),
+            emailDelivery: emailDelivery,
+            phoneDelivery: phoneDelivery,
+            federatedLogin: nil
+        )
+
+        let emptyJwks = """
+        {"keys":[]}
+        """
+
+        let loginView = Passage.Configuration.Views.LoginView(
+            style: .minimalism,
+            theme: Passage.Views.Theme(colors: .defaultLight),
+            identifier: .email
+        )
+        let viewsConfig = Passage.Configuration.Views(login: loginView)
+
+        let configuration = try Passage.Configuration(
+            origin: URL(string: "http://localhost:8080")!,
+            routes: .init(),
+            tokens: .init(
+                issuer: "test-issuer",
+                accessToken: .init(timeToLive: 3600),
+                refreshToken: .init(timeToLive: 86400)
+            ),
+            sessions: .init(enabled: true),
+            jwt: .init(jwks: .init(json: emptyJwks)),
+            verification: .init(
+                email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                useQueues: false
+            ),
+            restoration: .init(
+                email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                useQueues: false
+            ),
+            views: viewsConfig
+        )
+
+        let hooks = Passage.Hooks(
+            account: .hook(isSessionRevoked: { _, _ in true })
+        )
+
+        try await app.passage.configure(
+            services: services,
+            configuration: configuration,
+            hooks: hooks
+        )
+
+        let authenticated = app
+            .grouped(PassageSessionAuthenticator())
+            .grouped(PassageBearerAuthenticator())
+
+        authenticated.get("test-session-auth") { req -> String in
+            if let user = req.auth.get(Passage.OnlyForTest.InMemoryUser.self) {
+                return "authenticated:\(user.id ?? "no-id")"
+            }
+            return "not-authenticated"
+        }
+
         let guarded = authenticated.grouped(PassageGuard())
         guarded.get("test-protected") { req -> String in
             let user = try req.passage.user
@@ -93,7 +179,6 @@ struct `Sessions Authentication Integration Tests` {
 
     /// Configures a test Vapor application with Passage and session support disabled
     @Sendable private func configureWithoutSession(_ app: Application) async throws {
-        // Add HMAC key for JWT signing
         await app.jwt.keys.add(
             hmac: HMACKey(from: "test-secret-key-for-jwt-signing"),
             digestAlgorithm: .sha256,
@@ -164,17 +249,15 @@ struct `Sessions Authentication Integration Tests` {
     // MARK: - Login with Sessions Tests
 
     @Test
-    func `Login with session enabled sets session cookie`() async throws {
+    func `Form login with session enabled sets session cookie`() async throws {
         try await withApp(configure: configureWithSession) { app in
             try await createTestUser(app: app)
 
             try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
-                try req.content.encode([
-                    "email": "user@example.com",
-                    "password": "password123"
-                ])
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "user@example.com", "password": "password123"], as: .urlEncodedForm)
             }, afterResponse: { res async throws in
-                #expect(res.status == .ok)
+                #expect(res.status == .seeOther || res.status == .found)
 
                 // Check that a session cookie was set
                 let setCookieHeader = res.headers[.setCookie]
@@ -196,9 +279,30 @@ struct `Sessions Authentication Integration Tests` {
             }, afterResponse: { res async throws in
                 #expect(res.status == .ok)
 
-                // Check that no session cookie was set
                 let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
                 // When sessions are disabled, there should be no session cookie
+                #expect(!hasSessionCookie)
+            })
+        }
+    }
+
+    @Test
+    func `JSON login with sessions enabled returns tokens and no session cookie`() async throws {
+        try await withApp(configure: configureWithSession) { app in
+            try await createTestUser(app: app)
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode([
+                    "email": "user@example.com",
+                    "password": "password123"
+                ])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+
+                let authUser = try res.content.decode(AuthUser.self)
+                #expect(authUser.accessToken.isEmpty == false)
+
+                let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
                 #expect(!hasSessionCookie)
             })
         }
@@ -213,16 +317,12 @@ struct `Sessions Authentication Integration Tests` {
 
             var sessionCookie: String?
 
-            // First, login to get a session
             try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
-                try req.content.encode([
-                    "email": "user@example.com",
-                    "password": "password123"
-                ])
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "user@example.com", "password": "password123"], as: .urlEncodedForm)
             }, afterResponse: { res async throws in
-                #expect(res.status == .ok)
+                #expect(res.status == .seeOther || res.status == .found)
 
-                // Extract session cookie
                 if let cookieHeader = res.headers[.setCookie].first(where: { $0.contains("vapor-session") }) {
                     // Parse the cookie value
                     let parts = cookieHeader.split(separator: ";")
@@ -258,9 +358,41 @@ struct `Sessions Authentication Integration Tests` {
                 let body = String(buffer: res.body)
                 #expect(body == "not-authenticated")
 
-                // Check that no session cookie was set
                 let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
                 #expect(!hasSessionCookie)
+            })
+        }
+    }
+
+    @Test
+    func `Revoked cookie session is not authenticated`() async throws {
+        try await withApp(configure: configureWithSessionAndRevokedHook) { app in
+            try await createTestUser(app: app)
+
+            var sessionCookie: String?
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "user@example.com", "password": "password123"], as: .urlEncodedForm)
+            }, afterResponse: { res async throws in
+                #expect(res.status == .seeOther || res.status == .found)
+
+                if let cookieHeader = res.headers[.setCookie].first(where: { $0.contains("vapor-session") }) {
+                    let parts = cookieHeader.split(separator: ";")
+                    if let cookiePart = parts.first {
+                        sessionCookie = String(cookiePart)
+                    }
+                }
+            })
+
+            #expect(sessionCookie != nil)
+
+            try await app.testing().test(.GET, "test-protected", beforeRequest: { req in
+                if let cookie = sessionCookie {
+                    req.headers.add(name: .cookie, value: cookie)
+                }
+            }, afterResponse: { res async in
+                #expect(res.status == .unauthorized)
             })
         }
     }
@@ -273,19 +405,12 @@ struct `Sessions Authentication Integration Tests` {
             try await createTestUser(app: app)
 
             var sessionCookie: String?
-            var accessToken: String?
 
-            // Login to get session and tokens
             try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
-                try req.content.encode([
-                    "email": "user@example.com",
-                    "password": "password123"
-                ])
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "user@example.com", "password": "password123"], as: .urlEncodedForm)
             }, afterResponse: { res async throws in
-                #expect(res.status == .ok)
-
-                let authUser = try res.content.decode(AuthUser.self)
-                accessToken = authUser.accessToken
+                #expect(res.status == .seeOther || res.status == .found)
 
                 if let cookieHeader = res.headers[.setCookie].first(where: { $0.contains("vapor-session") }) {
                     let parts = cookieHeader.split(separator: ";")
@@ -296,15 +421,10 @@ struct `Sessions Authentication Integration Tests` {
             })
 
             #expect(sessionCookie != nil)
-            #expect(accessToken != nil)
 
-            // Logout with both session cookie and bearer token
             try await app.testing().test(.POST, "auth/logout", beforeRequest: { req in
                 if let cookie = sessionCookie {
                     req.headers.add(name: .cookie, value: cookie)
-                }
-                if let token = accessToken {
-                    req.headers.bearerAuthorization = BearerAuthorization(token: token)
                 }
                 try req.content.encode([String: String]())
             }, afterResponse: { res async in
@@ -333,14 +453,11 @@ struct `Sessions Authentication Integration Tests` {
 
             var sessionCookie: String?
 
-            // Login to get session
             try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
-                try req.content.encode([
-                    "email": "user@example.com",
-                    "password": "password123"
-                ])
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "user@example.com", "password": "password123"], as: .urlEncodedForm)
             }, afterResponse: { res async throws in
-                #expect(res.status == .ok)
+                #expect(res.status == .seeOther || res.status == .found)
 
                 if let cookieHeader = res.headers[.setCookie].first(where: { $0.contains("vapor-session") }) {
                     let parts = cookieHeader.split(separator: ";")
@@ -378,14 +495,11 @@ struct `Sessions Authentication Integration Tests` {
             var sessionCookie: String?
             var user2AccessToken: String?
 
-            // Login as user1 to get session
             try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
-                try req.content.encode([
-                    "email": "user1@example.com",
-                    "password": "password123"
-                ])
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "user1@example.com", "password": "password123"], as: .urlEncodedForm)
             }, afterResponse: { res async throws in
-                #expect(res.status == .ok)
+                #expect(res.status == .seeOther || res.status == .found)
 
                 if let cookieHeader = res.headers[.setCookie].first(where: { $0.contains("vapor-session") }) {
                     let parts = cookieHeader.split(separator: ";")
@@ -395,7 +509,6 @@ struct `Sessions Authentication Integration Tests` {
                 }
             })
 
-            // Login as user2 to get access token
             try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
                 try req.content.encode([
                     "email": "user2@example.com",
@@ -437,14 +550,11 @@ struct `Sessions Authentication Integration Tests` {
 
             var sessionCookie: String?
 
-            // Login to get session
             try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
-                try req.content.encode([
-                    "email": "user@example.com",
-                    "password": "password123"
-                ])
+                req.headers.replaceOrAdd(name: .accept, value: "text/html")
+                try req.content.encode(["email": "user@example.com", "password": "password123"], as: .urlEncodedForm)
             }, afterResponse: { res async throws in
-                #expect(res.status == .ok)
+                #expect(res.status == .seeOther || res.status == .found)
 
                 if let cookieHeader = res.headers[.setCookie].first(where: { $0.contains("vapor-session") }) {
                     let parts = cookieHeader.split(separator: ";")

--- a/Tests/PassageTests/Integration/Middleware/SessionRevocationIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Middleware/SessionRevocationIntegrationTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import JWT
+@testable import Passage
+@testable import PassageOnlyForTest
+import Testing
+import Vapor
+import VaporTesting
+
+@Suite(.tags(.integration))
+struct `Session Revocation Integration Tests` {
+
+    final class SessionRevocationSpy: @unchecked Sendable {
+        var sessionRevokedCalls: [(UUID, Int)] = []
+
+        func makeAccountHook() -> any Passage.Hooks.Account {
+            _AccountHooksClosures.hook(
+                isSessionRevoked: { [self] sessionId, _ in
+                    self.sessionRevokedCalls.append((sessionId, self.sessionRevokedCalls.count))
+                    return self.shouldRevoke(sessionId)
+                }
+            )
+        }
+
+        private var revokedSessions: Set<UUID> = []
+
+        func revoke(_ sessionId: UUID) {
+            revokedSessions.insert(sessionId)
+        }
+
+        func shouldRevoke(_ sessionId: UUID) -> Bool {
+            revokedSessions.contains(sessionId)
+        }
+    }
+
+    @Sendable private func configure(
+        _ app: Application,
+        hooks: Passage.Hooks = .init()
+    ) async throws {
+        await app.jwt.keys.add(
+            hmac: HMACKey(from: "test-secret-key-for-jwt-signing"),
+            digestAlgorithm: .sha256,
+            kid: JWKIdentifier(string: "test-key")
+        )
+
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let services = Passage.Services(
+            store: store,
+            random: DefaultRandomGenerator(),
+            emailDelivery: nil,
+            phoneDelivery: nil,
+            federatedLogin: nil
+        )
+
+        let emptyJwks = """
+        {"keys":[]}
+        """
+
+        let configuration = try Passage.Configuration(
+            origin: URL(string: "http://localhost:8080")!,
+            routes: .init(),
+            tokens: .init(
+                issuer: "test-issuer",
+                accessToken: .init(timeToLive: 3600),
+                refreshToken: .init(timeToLive: 86400)
+            ),
+            jwt: .init(jwks: .init(json: emptyJwks)),
+            verification: .init(
+                email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                useQueues: false
+            ),
+            restoration: .init(
+                email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                useQueues: false
+            )
+        )
+
+        try await app.passage.configure(
+            services: services,
+            configuration: configuration,
+            hooks: hooks
+        )
+
+        let protected = app.grouped(PassageBearerAuthenticator())
+        protected.get("protected-route") { req -> String in
+            if let user = req.auth.get(Passage.OnlyForTest.InMemoryUser.self) {
+                return "authorized:\(user.id ?? "no-id")"
+            }
+            return "not-authorized"
+        }
+    }
+
+    @Sendable private func createTestUser(
+        app: Application,
+        email: String = "user@example.com",
+        password: String = "password123"
+    ) async throws -> String {
+        let store = app.passage.storage.services.store
+        let passwordHash = try await app.password.async.hash(password)
+        let identifier = Identifier.email(email)
+        let credential = Credential.password(passwordHash)
+        let user = try await store.users.create(identifier: identifier, with: credential)
+        try await store.users.markEmailVerified(for: user)
+        return user.id as! String
+    }
+
+    @Test
+    func `bearer token with revoked sessionId returns 401`() async throws {
+        let spy = SessionRevocationSpy()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()))
+        }) { app in
+            _ = try await createTestUser(app: app, email: "revoked1@test.com")
+
+            var accessToken: String = ""
+            var sessionId: UUID?
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "revoked1@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                accessToken = authUser.accessToken
+                let decodedToken = try await app.jwt.keys.verify(authUser.accessToken, as: AccessToken.self)
+                sessionId = decodedToken.sessionId
+            })
+
+            spy.revoke(sessionId!)
+
+            try await app.testing().test(.GET, "protected-route", beforeRequest: { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: accessToken)
+            }, afterResponse: { res async in
+                #expect(res.status == .unauthorized)
+            })
+
+            #expect(spy.sessionRevokedCalls.count >= 1)
+            #expect(spy.sessionRevokedCalls[0].0 == sessionId!)
+        }
+    }
+
+    @Test
+    func `bearer token with active sessionId returns 200`() async throws {
+        let spy = SessionRevocationSpy()
+
+        try await withApp(configure: { app in
+            try await self.configure(app, hooks: .init(account: spy.makeAccountHook()))
+        }) { app in
+            _ = try await createTestUser(app: app, email: "revoked2@test.com")
+
+            var accessToken: String = ""
+            var sessionId: UUID?
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "revoked2@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                accessToken = authUser.accessToken
+                let decodedToken = try await app.jwt.keys.verify(authUser.accessToken, as: AccessToken.self)
+                sessionId = decodedToken.sessionId
+            })
+
+            try await app.testing().test(.GET, "protected-route", beforeRequest: { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: accessToken)
+            }, afterResponse: { res async in
+                #expect(res.status == .ok)
+                let body = String(buffer: res.body)
+                #expect(body.contains("authorized:"))
+            })
+
+            #expect(spy.sessionRevokedCalls.count >= 1)
+            #expect(spy.sessionRevokedCalls[0].0 == sessionId!)
+        }
+    }
+
+}

--- a/Tests/PassageTests/Integration/Tokens/SessionIdIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Tokens/SessionIdIntegrationTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import JWT
+@testable import Passage
+@testable import PassageOnlyForTest
+import Testing
+import Vapor
+import VaporTesting
+
+@Suite(.tags(.integration))
+struct `Session ID Integration Tests` {
+
+    @Sendable private func configure(_ app: Application) async throws {
+        await app.jwt.keys.add(
+            hmac: HMACKey(from: "test-secret-key-for-jwt-signing"),
+            digestAlgorithm: .sha256,
+            kid: JWKIdentifier(string: "test-key")
+        )
+
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let services = Passage.Services(
+            store: store,
+            random: DefaultRandomGenerator(),
+            emailDelivery: nil,
+            phoneDelivery: nil,
+            federatedLogin: nil
+        )
+
+        let emptyJwks = """
+        {"keys":[]}
+        """
+
+        let configuration = try Passage.Configuration(
+            origin: URL(string: "http://localhost:8080")!,
+            routes: .init(),
+            tokens: .init(
+                issuer: "test-issuer",
+                accessToken: .init(timeToLive: 3600),
+                refreshToken: .init(timeToLive: 86400)
+            ),
+            sessions: .init(enabled: false),
+            jwt: .init(jwks: .init(json: emptyJwks)),
+            passwordless: .init(
+                emailMagicLink: .email(
+                    useQueues: false,
+                    linkExpiration: 3600,
+                    maxAttempts: 3,
+                    autoCreateUser: false,
+                    requireSameBrowser: true
+                )
+            ),
+            verification: .init(
+                email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                useQueues: false
+            ),
+            restoration: .init(
+                email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                useQueues: false
+            )
+        )
+
+        try await app.passage.configure(services: services, configuration: configuration)
+
+        let protected = app.grouped(PassageBearerAuthenticator())
+        protected.get("get-session-id") { req -> String in
+            if let sessionId = req.passage.sessionId {
+                return sessionId.uuidString
+            }
+            return "no-session-id"
+        }
+
+        app.post("revoke-session", ":sid") { req async throws -> String in
+            guard let sidParam = req.parameters.get("sid"),
+                  let sessionId = UUID(uuidString: sidParam) else {
+                throw Abort(.badRequest, reason: "Invalid session ID")
+            }
+            try await req.passage.revoke(sessionId: sessionId)
+            return "revoked"
+        }
+    }
+
+    @Sendable private func createTestUser(
+        app: Application,
+        email: String = "user@example.com",
+        password: String = "password123"
+    ) async throws -> String {
+        let store = app.passage.storage.services.store
+        let passwordHash = try await app.password.async.hash(password)
+        let identifier = Identifier.email(email)
+        let credential = Credential.password(passwordHash)
+        let user = try await store.users.create(identifier: identifier, with: credential)
+        try await store.users.markEmailVerified(for: user)
+        return user.id as! String
+    }
+
+    @Test
+    func `refresh preserves the sessionId from login`() async throws {
+        try await withApp(configure: configure) { app in
+            try await createTestUser(app: app, email: "sid1@test.com")
+
+            var firstSessionId: UUID?
+            var refreshToken: String = ""
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "sid1@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                refreshToken = authUser.refreshToken
+                let decodedToken = try await app.jwt.keys.verify(authUser.accessToken, as: AccessToken.self)
+                firstSessionId = decodedToken.sessionId
+            })
+
+            var refreshedSessionId: UUID?
+            try await app.testing().test(.POST, "auth/refresh-token", beforeRequest: { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                let decodedToken = try await app.jwt.keys.verify(authUser.accessToken, as: AccessToken.self)
+                refreshedSessionId = decodedToken.sessionId
+            })
+
+            #expect(refreshedSessionId == firstSessionId)
+        }
+    }
+
+    @Test
+    func `refresh token fails after session revocation`() async throws {
+        try await withApp(configure: configure) { app in
+            try await createTestUser(app: app, email: "sid2@test.com")
+
+            var sessionId: UUID?
+            var refreshToken: String = ""
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "sid2@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                refreshToken = authUser.refreshToken
+                let decodedToken = try await app.jwt.keys.verify(authUser.accessToken, as: AccessToken.self)
+                sessionId = decodedToken.sessionId
+            })
+
+            try await app.testing().test(.POST, "revoke-session/\(sessionId!.uuidString)", beforeRequest: { req in
+            }, afterResponse: { res async in
+                #expect(res.status == .ok)
+            })
+
+            try await app.testing().test(.POST, "auth/refresh-token", beforeRequest: { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            }, afterResponse: { res async in
+                #expect(res.status == .unauthorized)
+            })
+        }
+    }
+
+    @Test
+    func `authenticated bearer request can access sessionId`() async throws {
+        try await withApp(configure: configure) { app in
+            let userId = try await createTestUser(app: app, email: "sid3@test.com")
+
+            var accessToken: String = ""
+            var loginSessionId: UUID?
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "sid3@test.com", "password": "password123"])
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let authUser = try res.content.decode(AuthUser.self)
+                accessToken = authUser.accessToken
+                let decodedToken = try await app.jwt.keys.verify(authUser.accessToken, as: AccessToken.self)
+                loginSessionId = decodedToken.sessionId
+            })
+
+            try await app.testing().test(.GET, "get-session-id", beforeRequest: { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: accessToken)
+            }, afterResponse: { res async throws in
+                #expect(res.status == .ok)
+                let body = String(buffer: res.body)
+                #expect(body == loginSessionId!.uuidString)
+            })
+        }
+    }
+
+    @Test
+    func `browser session stores and retrieves sessionId`() async throws {
+        var configureWithSessions: (@Sendable (Application) async throws -> Void)?
+        configureWithSessions = { app in
+            await app.jwt.keys.add(
+                hmac: HMACKey(from: "test-secret-key-for-jwt-signing"),
+                digestAlgorithm: .sha256,
+                kid: JWKIdentifier(string: "test-key")
+            )
+
+            app.middleware.use(app.sessions.middleware)
+
+            let store = Passage.OnlyForTest.InMemoryStore()
+            let services = Passage.Services(
+                store: store,
+                random: DefaultRandomGenerator(),
+                emailDelivery: nil,
+                phoneDelivery: nil,
+                federatedLogin: nil
+            )
+
+            let emptyJwks = """
+            {"keys":[]}
+            """
+
+            let configuration = try Passage.Configuration(
+                origin: URL(string: "http://localhost:8080")!,
+                routes: .init(),
+                tokens: .init(
+                    issuer: "test-issuer",
+                    accessToken: .init(timeToLive: 3600),
+                    refreshToken: .init(timeToLive: 86400)
+                ),
+                sessions: .init(enabled: true),
+                jwt: .init(jwks: .init(json: emptyJwks)),
+                verification: .init(
+                    email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                    phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                    useQueues: false
+                ),
+                restoration: .init(
+                    email: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                    phone: .init(codeLength: 6, codeExpiration: 600, maxAttempts: 5),
+                    useQueues: false
+                )
+            )
+
+            try await app.passage.configure(services: services, configuration: configuration)
+
+            app.get("get-session-id") { req -> String in
+                if let sessionId = req.passage.sessionId {
+                    return sessionId.uuidString
+                }
+                return "no-session-id"
+            }
+        }
+
+        try await withApp(configure: configureWithSessions!) { app in
+            try await createTestUser(app: app, email: "sid4@test.com")
+
+            try await app.testing().test(.POST, "auth/login", beforeRequest: { req in
+                try req.content.encode(["email": "sid4@test.com", "password": "password123"])
+            }, afterResponse: { res async in
+                #expect(res.status == .ok)
+            })
+        }
+    }
+}

--- a/Tests/PassageTests/Integration/Views/ViewsIntegrationTests.swift
+++ b/Tests/PassageTests/Integration/Views/ViewsIntegrationTests.swift
@@ -27,8 +27,13 @@ struct `Views Integration Tests` {
         _ app: Application,
         viewsConfig: Passage.Configuration.Views,
         captureRenderer: CapturingViewRenderer? = nil,
-        captured: CapturedMessages? = nil
+        captured: CapturedMessages? = nil,
+        sessionsEnabled: Bool = false
     ) async throws {
+        if sessionsEnabled {
+            app.middleware.use(app.sessions.middleware)
+        }
+
         // Use capturing renderer if provided (for view rendering tests)
         // Otherwise use default (for 404 tests)
         if let renderer = captureRenderer {
@@ -78,6 +83,7 @@ struct `Views Integration Tests` {
                 accessToken: .init(timeToLive: 3600),
                 refreshToken: .init(timeToLive: 86400)
             ),
+            sessions: .init(enabled: sessionsEnabled),
             jwt: .init(jwks: .init(json: emptyJwks)),
             passwordless: .init(
                 emailMagicLink: .email(useQueues: true)
@@ -225,9 +231,8 @@ struct `Views Integration Tests` {
         let viewsConfig = Passage.Configuration.Views(login: loginView)
 
         try await withApp { app in
-            try await configure(app, viewsConfig: viewsConfig)
+            try await configure(app, viewsConfig: viewsConfig, sessionsEnabled: true)
 
-            // Create a verified user first
             let email = "test@example.com"
             let password = "SecurePassword123!"
             let passwordHash = try await app.password.async.hash(password)
@@ -237,10 +242,8 @@ struct `Views Integration Tests` {
             let store = app.passage.storage.services.store
             let user = try await store.users.create(identifier: identifier, with: credential)
 
-            // Mark email as verified
             try await store.users.markEmailVerified(for: user)
 
-            // Submit login form with correct credentials
             try await app.testing().test(.POST, "/auth/login", headers: [
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
@@ -257,6 +260,9 @@ struct `Views Integration Tests` {
                 #expect(location?.contains("success=") == true)
                 // Success message contains "successfully logged in"
                 #expect(location?.contains("successfully") == true || location?.contains("logged+in") == true)
+
+                let hasSessionCookie = res.headers[.setCookie].contains { $0.contains("vapor-session") }
+                #expect(hasSessionCookie)
             })
         }
     }
@@ -307,9 +313,8 @@ struct `Views Integration Tests` {
         let viewsConfig = Passage.Configuration.Views(login: loginView)
 
         try await withApp { app in
-            try await configure(app, viewsConfig: viewsConfig)
+            try await configure(app, viewsConfig: viewsConfig, sessionsEnabled: true)
 
-            // Create a verified user first
             let email = "test@example.com"
             let password = "SecurePassword123!"
             let passwordHash = try await app.password.async.hash(password)
@@ -319,15 +324,12 @@ struct `Views Integration Tests` {
             let store = app.passage.storage.services.store
             let user = try await store.users.create(identifier: identifier, with: credential)
 
-            // Mark email as verified
             try await store.users.markEmailVerified(for: user)
 
-            // Submit login form with correct credentials
             try await app.testing().test(.POST, "/auth/login", headers: [
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)&password=\(password)&confirmPassword=\(password)"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should redirect to custom success location
@@ -359,12 +361,49 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=nonexistent@example.com&password=wrongpassword"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should redirect to custom failure location
                 let location = res.headers.first(name: .location)
                 #expect(location == "/error")
+            })
+        }
+    }
+
+    @Test
+    func `Login form submission with sessions disabled redirects with sessionsDisabled error`() async throws {
+        let loginView = Passage.Configuration.Views.LoginView(
+            style: .minimalism,
+            theme: Passage.Views.Theme(colors: .defaultLight),
+            identifier: .email
+        )
+        let viewsConfig = Passage.Configuration.Views(login: loginView)
+
+        try await withApp { app in
+            try await configure(app, viewsConfig: viewsConfig, sessionsEnabled: false)
+
+            let email = "test@example.com"
+            let password = "SecurePassword123!"
+            let passwordHash = try await app.password.async.hash(password)
+
+            let identifier = Identifier.email(email)
+            let credential = Credential.password(passwordHash)
+            let store = app.passage.storage.services.store
+            let user = try await store.users.create(identifier: identifier, with: credential)
+
+            try await store.users.markEmailVerified(for: user)
+
+            try await app.testing().test(.POST, "/auth/login", headers: [
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "text/html"
+            ], body: .init(string: "email=\(email)&password=\(password)&confirmPassword=\(password)"), afterResponse: { res in
+                #expect(res.status == .seeOther || res.status == .found)
+
+                let location = res.headers.first(name: .location)
+                #expect(location != nil)
+                #expect(location?.contains("/auth/login") == true)
+                #expect(location?.contains("error=") == true)
+                #expect(location?.contains("Sessions") == true || location?.contains("disabled") == true)
             })
         }
     }
@@ -456,7 +495,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)&password=\(password)&confirmPassword=\(password)"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should have Location header
@@ -497,7 +535,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)&password=\(password)&confirmPassword=\(password)"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should have Location header
@@ -536,7 +573,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)&password=\(password)&confirmPassword=\(password)"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should redirect to custom success location
@@ -577,7 +613,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)&password=\(password)&confirmPassword=\(password)"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should redirect to custom failure location
@@ -686,7 +721,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should have Location header
@@ -716,7 +750,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=invalid-email"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should have Location header with error
@@ -839,7 +872,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)&code=\(resetCode)&newPassword=\(newPassword)"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should have Location header
@@ -878,7 +910,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)&code=INVALID&newPassword=NewPassword456!"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should have Location header with error
@@ -932,7 +963,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)&code=\(resetCode)&newPassword=\(newPassword)"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should redirect to custom success location
@@ -972,7 +1002,6 @@ struct `Views Integration Tests` {
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Accept": "text/html"
             ], body: .init(string: "email=\(email)&code=INVALID&newPassword=NewPassword456!"), afterResponse: { res in
-                // Should redirect
                 #expect(res.status == .seeOther || res.status == .found)
 
                 // Should redirect to custom failure location
@@ -1366,7 +1395,7 @@ struct `Views Integration Tests` {
 
         try await withApp { app in
             let renderer = CapturingViewRenderer(eventLoop: app.eventLoopGroup.any())
-            try await configure(app, viewsConfig: viewsConfig, captureRenderer: renderer, captured: captured)
+            try await configure(app, viewsConfig: viewsConfig, captureRenderer: renderer, captured: captured, sessionsEnabled: true)
 
             let email = "verify@example.com"
 

--- a/Tests/PassageTests/Unit/Core/PassageContextTests.swift
+++ b/Tests/PassageTests/Unit/Core/PassageContextTests.swift
@@ -47,8 +47,8 @@ struct `PassageContext Tests` {
     @Test
     func `PassageContext has login method`() {
         // Verify PassageContext has a login method that accepts a User
-        func checkLoginMethod(_ context: PassageContext, _ user: any User) {
-            context.login(user)
+        func checkLoginMethod(_ context: PassageContext, _ user: any User) async throws {
+            _ = try await context.login(user, origin: .login, via: .bearer)
         }
         // Test passes if it compiles
     }

--- a/Tests/PassageTests/Unit/Core/SessionIdStorageTests.swift
+++ b/Tests/PassageTests/Unit/Core/SessionIdStorageTests.swift
@@ -1,0 +1,64 @@
+@testable import Passage
+import Foundation
+import Testing
+import Vapor
+
+@Suite(.tags(.unit))
+struct `Session ID Storage Tests` {
+
+    @Test
+    func `set sessionId stores UUID string in data`() {
+        let session = Session(id: SessionID(string: "test-session"), data: [:])
+        let uuid = UUID()
+
+        session.sessionId = uuid
+
+        #expect(session.data[Session.sessionIdKey] == uuid.uuidString)
+    }
+
+    @Test
+    func `get sessionId round-trips UUID`() {
+        let uuid = UUID()
+        let session = Session(id: SessionID(string: "test-session"), data: [:])
+        session.sessionId = uuid
+
+        let retrieved = session.sessionId
+
+        #expect(retrieved == uuid)
+    }
+
+    @Test
+    func `set sessionId to nil removes key from data`() {
+        let session = Session(id: SessionID(string: "test-session"), data: [:])
+        let uuid = UUID()
+        session.sessionId = uuid
+
+        session.sessionId = nil
+
+        #expect(session.data[Session.sessionIdKey] == nil)
+    }
+
+    @Test
+    func `get sessionId returns nil when key not in data`() {
+        let session = Session(id: SessionID(string: "test-session"), data: [:])
+
+        let retrieved = session.sessionId
+
+        #expect(retrieved == nil)
+    }
+
+    @Test
+    func `get sessionId returns nil for malformed string`() {
+        let session = Session(id: SessionID(string: "test-session"), data: [:])
+        session.data[Session.sessionIdKey] = "not-a-valid-uuid"
+
+        let retrieved = session.sessionId
+
+        #expect(retrieved == nil)
+    }
+
+    @Test
+    func `sessionId uses correct data key`() {
+        #expect(Session.sessionIdKey == "_PassageSessionId")
+    }
+}

--- a/Tests/PassageTests/Unit/Errors/AuthenticationErrorTests.swift
+++ b/Tests/PassageTests/Unit/Errors/AuthenticationErrorTests.swift
@@ -33,7 +33,8 @@ struct `Authentication Error Tests` {
     @Test(arguments: [
         (AuthenticationError.invalidRefreshToken, HTTPResponseStatus.unauthorized),
         (AuthenticationError.refreshTokenExpired, HTTPResponseStatus.unauthorized),
-        (AuthenticationError.refreshTokenNotFound, HTTPResponseStatus.notFound)
+        (AuthenticationError.refreshTokenNotFound, HTTPResponseStatus.notFound),
+        (AuthenticationError.sessionRevoked, HTTPResponseStatus.unauthorized)
     ])
     func `Token error status codes`(error: AuthenticationError, expectedStatus: HTTPResponseStatus) {
         #expect(error.status == expectedStatus)
@@ -117,7 +118,8 @@ struct `Authentication Error Tests` {
     @Test(arguments: [
         (AuthenticationError.invalidRefreshToken, "The refresh token is invalid."),
         (AuthenticationError.refreshTokenExpired, "The refresh token has expired."),
-        (AuthenticationError.refreshTokenNotFound, "Refresh token not found.")
+        (AuthenticationError.refreshTokenNotFound, "Refresh token not found."),
+        (AuthenticationError.sessionRevoked, "The session has been revoked.")
     ])
     func `Token error reasons`(error: AuthenticationError, expectedReason: String) {
         #expect(error.reason == expectedReason)
@@ -268,6 +270,7 @@ struct `Authentication Error Tests` {
             .invalidRefreshToken,
             .refreshTokenExpired,
             .refreshTokenNotFound,
+            .sessionRevoked,
             .userNotFound,
             .emailNotSet,
             .emailAlreadyVerified,
@@ -307,6 +310,7 @@ struct `Authentication Error Tests` {
             .invalidRefreshToken,
             .refreshTokenExpired,
             .refreshTokenNotFound,
+            .sessionRevoked,
             .userNotFound,
             .emailNotSet,
             .emailAlreadyVerified,

--- a/Tests/PassageTests/Unit/Features/Account/AccountMethodsTests.swift
+++ b/Tests/PassageTests/Unit/Features/Account/AccountMethodsTests.swift
@@ -81,7 +81,8 @@ struct `Account Methods Unit Tests` {
     @Sendable private func createRefreshToken(
         app: Application,
         user: any User,
-        expiresAt: Date? = nil
+        expiresAt: Date? = nil,
+        sessionId: UUID = UUID()
     ) async throws -> String {
         let store = app.passage.storage.services.store
         let random = app.passage.storage.services.random
@@ -93,7 +94,8 @@ struct `Account Methods Unit Tests` {
         try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: tokenHash,
-            expiresAt: expiration
+            expiresAt: expiration,
+            sessionId: UUID()
         )
 
         return opaqueToken
@@ -331,7 +333,8 @@ struct `Account Methods Unit Tests` {
             expiresAt: Date().addingTimeInterval(3600),
             issuer: "test-issuer",
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         let found = try await account.user(for: accessToken)
@@ -352,7 +355,8 @@ struct `Account Methods Unit Tests` {
             expiresAt: Date().addingTimeInterval(3600),
             issuer: "test-issuer",
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         await #expect(throws: AuthenticationError.self) {

--- a/Tests/PassageTests/Unit/Features/Account/AccountMethodsTests.swift
+++ b/Tests/PassageTests/Unit/Features/Account/AccountMethodsTests.swift
@@ -95,7 +95,7 @@ struct `Account Methods Unit Tests` {
             for: user,
             tokenHash: tokenHash,
             expiresAt: expiration,
-            sessionId: UUID()
+            sessionId: sessionId
         )
 
         return opaqueToken

--- a/Tests/PassageTests/Unit/Features/Tokens/TokensMethodsTests.swift
+++ b/Tests/PassageTests/Unit/Features/Tokens/TokensMethodsTests.swift
@@ -77,7 +77,7 @@ struct `Tokens Methods Unit Tests` {
             for: user,
             tokenHash: tokenHash,
             expiresAt: expiration,
-            sessionId: UUID()
+            sessionId: sessionId
         )
 
         return opaqueToken

--- a/Tests/PassageTests/Unit/Features/Tokens/TokensMethodsTests.swift
+++ b/Tests/PassageTests/Unit/Features/Tokens/TokensMethodsTests.swift
@@ -63,7 +63,8 @@ struct `Tokens Methods Unit Tests` {
     @Sendable private func createRefreshToken(
         app: Application,
         user: any User,
-        expiresAt: Date? = nil
+        expiresAt: Date? = nil,
+        sessionId: UUID = UUID()
     ) async throws -> String {
         let store = app.passage.storage.services.store
         let random = app.passage.storage.services.random
@@ -75,7 +76,8 @@ struct `Tokens Methods Unit Tests` {
         try await store.tokens.createRefreshToken(
             for: user,
             tokenHash: tokenHash,
-            expiresAt: expiration
+            expiresAt: expiration,
+            sessionId: UUID()
         )
 
         return opaqueToken
@@ -94,7 +96,7 @@ struct `Tokens Methods Unit Tests` {
         let request = Request(application: app, on: app.eventLoopGroup.next())
         let tokens = Passage.Tokens(request: request)
 
-        let authUser = try await tokens.issue(for: user)
+        let authUser = try await tokens.issue(for: user, sessionId: UUID(), origin: .login)
 
         #expect(!authUser.accessToken.isEmpty)
         #expect(!authUser.refreshToken.isEmpty)
@@ -116,7 +118,7 @@ struct `Tokens Methods Unit Tests` {
         let tokens = Passage.Tokens(request: request)
 
         // Issue new tokens (should revoke existing)
-        _ = try await tokens.issue(for: user)
+        _ = try await tokens.issue(for: user, sessionId: UUID(), origin: .login)
 
         // Verify existing token is revoked
         await #expect(throws: AuthenticationError.self) {
@@ -137,7 +139,7 @@ struct `Tokens Methods Unit Tests` {
         let tokens = Passage.Tokens(request: request)
 
         // Issue new tokens without revoking existing
-        _ = try await tokens.issue(for: user, revokeExisting: false)
+        _ = try await tokens.issue(for: user, sessionId: UUID(), revokeExisting: false, origin: .login)
 
         // Verify existing token still works
         let authUser = try await tokens.refresh(using: existingToken)
@@ -155,7 +157,7 @@ struct `Tokens Methods Unit Tests` {
         let request = Request(application: app, on: app.eventLoopGroup.next())
         let tokens = Passage.Tokens(request: request)
 
-        let authUser = try await tokens.issue(for: user)
+        let authUser = try await tokens.issue(for: user, sessionId: UUID(), origin: .login)
 
         // Verify refresh token is in store
         let store = app.passage.storage.services.store
@@ -215,7 +217,8 @@ struct `Tokens Methods Unit Tests` {
         let refreshToken = try await createRefreshToken(
             app: app,
             user: user,
-            expiresAt: Date.now.addingTimeInterval(-3600) // Expired 1 hour ago
+            expiresAt: Date.now.addingTimeInterval(-3600), // Expired 1 hour ago
+            sessionId: UUID()
         )
 
         let request = Request(application: app, on: app.eventLoopGroup.next())

--- a/Tests/PassageTests/Unit/Hooks/AccountHooksClosuresTests.swift
+++ b/Tests/PassageTests/Unit/Hooks/AccountHooksClosuresTests.swift
@@ -262,6 +262,171 @@ struct `Account Hooks Closures Tests` {
         }
     }
 
+    // MARK: - Credential Issuance Hooks
+
+    @Test
+    func `Empty closures factory does not throw on willIssueCredential`() async throws {
+        let hook = _AccountHooksClosures.hook()
+        let app = try await makeApplication()
+        defer { Task { try await app.asyncShutdown() } }
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: Self.makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+
+        try await hook.willIssueCredential(issuance, on: request)
+    }
+
+    @Test
+    func `Empty closures factory completes silently on didIssueCredential`() async throws {
+        let hook = _AccountHooksClosures.hook()
+        let app = try await makeApplication()
+        defer { Task { try await app.asyncShutdown() } }
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: Self.makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+
+        await hook.didIssueCredential(issuance, on: request)
+    }
+
+    @Test
+    func `Empty closures factory returns false for isSessionRevoked`() async throws {
+        let hook = _AccountHooksClosures.hook()
+        let app = try await makeApplication()
+        defer { Task { try await app.asyncShutdown() } }
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+
+        let result = await hook.isSessionRevoked(UUID(), on: request)
+        #expect(result == false)
+    }
+
+    @Test
+    func `willIssueCredential closure receives issuance`() async throws {
+        final class IssuanceCapture: @unchecked Sendable {
+            var issuance: CredentialIssuance?
+        }
+        let capture = IssuanceCapture()
+
+        let hook = _AccountHooksClosures.hook(
+            willIssueCredential: { issuance, _ in
+                capture.issuance = issuance
+            }
+        )
+        let app = try await makeApplication()
+        defer { Task { try await app.asyncShutdown() } }
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let sessionId = UUID()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: Self.makeUser(id: "issuance-user"),
+            sessionId: sessionId,
+            store: store
+        )
+
+        try await hook.willIssueCredential(issuance, on: request)
+
+        #expect(capture.issuance?.sessionId == sessionId)
+        #expect((try? capture.issuance?.user.requiredIdAsString) == "issuance-user")
+    }
+
+    @Test
+    func `didIssueCredential closure receives issuance`() async throws {
+        final class IssuanceCapture: @unchecked Sendable {
+            var issuance: CredentialIssuance?
+        }
+        let capture = IssuanceCapture()
+
+        let hook = _AccountHooksClosures.hook(
+            didIssueCredential: { issuance, _ in
+                capture.issuance = issuance
+            }
+        )
+        let app = try await makeApplication()
+        defer { Task { try await app.asyncShutdown() } }
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let sessionId = UUID()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: Self.makeUser(id: "did-issuance-user"),
+            sessionId: sessionId,
+            store: store
+        )
+
+        await hook.didIssueCredential(issuance, on: request)
+
+        #expect(capture.issuance?.sessionId == sessionId)
+    }
+
+    @Test
+    func `isSessionRevoked closure returns true when set to true`() async throws {
+        let hook = _AccountHooksClosures.hook(
+            isSessionRevoked: { _, _ in true }
+        )
+        let app = try await makeApplication()
+        defer { Task { try await app.asyncShutdown() } }
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+
+        let sessionId = UUID()
+        let result = await hook.isSessionRevoked(sessionId, on: request)
+        #expect(result == true)
+    }
+
+    @Test
+    func `isSessionRevoked closure returns false when set to false`() async throws {
+        let hook = _AccountHooksClosures.hook(
+            isSessionRevoked: { _, _ in false }
+        )
+        let app = try await makeApplication()
+        defer { Task { try await app.asyncShutdown() } }
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+
+        let sessionId = UUID()
+        let result = await hook.isSessionRevoked(sessionId, on: request)
+        #expect(result == false)
+    }
+
+    @Test
+    func `willIssueCredential propagates errors thrown by closure`() async throws {
+        let hook = _AccountHooksClosures.hook(
+            willIssueCredential: { _, _ in throw TestError(tag: "issuance") }
+        )
+        let app = try await makeApplication()
+        defer { Task { try await app.asyncShutdown() } }
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: Self.makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+
+        await #expect(throws: TestError.self) {
+            try await hook.willIssueCredential(issuance, on: request)
+        }
+    }
+
     // MARK: - Conformance & Type Identity
 
     @Test

--- a/Tests/PassageTests/Unit/Protocols/RefreshTokenProtocolTests.swift
+++ b/Tests/PassageTests/Unit/Protocols/RefreshTokenProtocolTests.swift
@@ -36,6 +36,7 @@ struct `RefreshToken Protocol Tests` {
         var expiresAt: Date
         var revokedAt: Date?
         var replacedBy: UUID?
+        var sessionId: UUID
     }
 
     // MARK: - isExpired Tests
@@ -57,7 +58,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(-3600), // expired 1 hour ago
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.isExpired == true)
@@ -80,7 +82,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(3600), // expires in 1 hour
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.isExpired == false)
@@ -105,7 +108,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(3600),
             revokedAt: Date(),
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.isRevoked == true)
@@ -128,7 +132,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(3600),
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.isRevoked == false)
@@ -153,7 +158,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(3600),
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.isValid == true)
@@ -176,7 +182,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(-3600),
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.isValid == false)
@@ -199,7 +206,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(3600),
             revokedAt: Date(),
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.isValid == false)
@@ -222,7 +230,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(-3600),
             revokedAt: Date(),
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.isValid == false)
@@ -247,7 +256,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date(),
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
         #expect(token is MockRefreshToken)
     }
@@ -269,7 +279,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date(),
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
         #expect(token is MockRefreshToken)
     }
@@ -294,7 +305,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(3600),
             revokedAt: nil,
-            replacedBy: newTokenId
+            replacedBy: newTokenId,
+            sessionId: UUID()
         )
 
         #expect(token.replacedBy == newTokenId)
@@ -317,7 +329,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date().addingTimeInterval(3600),
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.replacedBy == nil)
@@ -343,7 +356,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: hash,
             expiresAt: Date(),
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.tokenHash == hash)
@@ -368,7 +382,8 @@ struct `RefreshToken Protocol Tests` {
             tokenHash: "hash",
             expiresAt: Date(),
             revokedAt: nil,
-            replacedBy: nil
+            replacedBy: nil,
+            sessionId: UUID()
         )
 
         #expect(token.user.id == userId)

--- a/Tests/PassageTests/Unit/Services/ExchangeTokenStoreProtocolTests.swift
+++ b/Tests/PassageTests/Unit/Services/ExchangeTokenStoreProtocolTests.swift
@@ -214,6 +214,9 @@ struct `ExchangeTokenStore Protocol Tests` {
             var restorationCodes: any Passage.RestorationCodeStore { fatalError() }
             var magicLinkTokens: any Passage.MagicLinkTokenStore { fatalError() }
             var exchangeTokens: any Passage.ExchangeTokenStore { MockExchangeTokenStore() }
+            func transaction<T: Sendable>(_ body: @Sendable (any Passage.Store) async throws -> T) async throws -> T {
+                try await body(self)
+            }
         }
 
         let store: any Passage.Store = TestStore()

--- a/Tests/PassageTests/Unit/Services/InMemoryTokenStoreTests.swift
+++ b/Tests/PassageTests/Unit/Services/InMemoryTokenStoreTests.swift
@@ -1,0 +1,381 @@
+@testable import Passage
+@testable import PassageOnlyForTest
+import Foundation
+import Testing
+
+@Suite(.tags(.unit))
+struct `InMemoryTokenStore Tests` {
+
+    private struct MockUser: User {
+        typealias Id = UUID
+        var id: UUID?
+        var email: String?
+        var phone: String?
+        var username: String?
+        var passwordHash: String?
+        var isAnonymous: Bool
+        var isEmailVerified: Bool
+        var isPhoneVerified: Bool
+
+        var sessionID: String {
+            guard let id = id else { fatalError("MockUser must have an ID") }
+            return id.uuidString
+        }
+    }
+
+    private func makeUser(id: UUID = UUID()) -> MockUser {
+        MockUser(
+            id: id,
+            email: "user@example.com",
+            phone: nil,
+            username: nil,
+            passwordHash: "hash",
+            isAnonymous: false,
+            isEmailVerified: false,
+            isPhoneVerified: false
+        )
+    }
+
+    @Test
+    func `createRefreshToken persists sessionId`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user = makeUser()
+        let sessionId = UUID()
+        let expiresAt = Date().addingTimeInterval(3600)
+
+        let token = try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-1",
+            expiresAt: expiresAt,
+            sessionId: sessionId
+        )
+
+        #expect(token.sessionId == sessionId)
+    }
+
+    @Test
+    func `createRefreshToken rows appear in refreshTokens list`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = try #require(inMemoryStore.tokens as? Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore)
+        let user = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+
+        try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-1",
+            expiresAt: expiresAt,
+            sessionId: UUID()
+        )
+        try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-2",
+            expiresAt: expiresAt,
+            sessionId: UUID()
+        )
+
+        #expect(store.refreshTokens.count == 2)
+        let hashes = Set(store.refreshTokens.map(\.tokenHash))
+        #expect(hashes.contains("hash-1"))
+        #expect(hashes.contains("hash-2"))
+    }
+
+    @Test
+    func `createRefreshToken with replacing sets replacedBy on old token`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+
+        let oldToken = try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-old",
+            expiresAt: expiresAt,
+            sessionId: UUID()
+        )
+
+        _ = try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-new",
+            expiresAt: expiresAt,
+            sessionId: UUID(),
+            replacing: oldToken
+        )
+
+        let foundOld = try await store.find(refreshTokenHash: "hash-old")
+        #expect(foundOld?.replacedBy != nil)
+    }
+
+    @Test
+    func `revokeRefreshTokens for user returns session ids of revoked tokens`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+        let sessionId1 = UUID()
+        let sessionId2 = UUID()
+
+        try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-1",
+            expiresAt: expiresAt,
+            sessionId: sessionId1
+        )
+        try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-2",
+            expiresAt: expiresAt,
+            sessionId: sessionId2
+        )
+
+        let revoked = try await store.revokeRefreshTokens(for: user)
+
+        #expect(revoked.contains(sessionId1))
+        #expect(revoked.contains(sessionId2))
+        #expect(revoked.count == 2)
+    }
+
+    @Test
+    func `revokeRefreshTokens deduplicates same sessionId`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+        let sessionId = UUID()
+
+        try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-1",
+            expiresAt: expiresAt,
+            sessionId: sessionId
+        )
+        try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-2",
+            expiresAt: expiresAt,
+            sessionId: sessionId
+        )
+
+        let revoked = try await store.revokeRefreshTokens(for: user)
+
+        #expect(revoked.count == 1)
+        #expect(revoked.first == sessionId)
+    }
+
+    @Test
+    func `revokeRefreshTokens skips already-revoked tokens`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+        let sessionId = UUID()
+
+        try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-1",
+            expiresAt: expiresAt,
+            sessionId: sessionId
+        )
+
+        let firstRevoke = try await store.revokeRefreshTokens(for: user)
+        #expect(firstRevoke.count == 1)
+
+        let secondRevoke = try await store.revokeRefreshTokens(for: user)
+        #expect(secondRevoke == [])
+    }
+
+    @Test
+    func `revokeRefreshTokens does not touch other users tokens`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user1 = makeUser()
+        let user2 = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+        let sessionId1 = UUID()
+        let sessionId2 = UUID()
+
+        try await store.createRefreshToken(
+            for: user1,
+            tokenHash: "hash-1",
+            expiresAt: expiresAt,
+            sessionId: sessionId1
+        )
+        try await store.createRefreshToken(
+            for: user2,
+            tokenHash: "hash-2",
+            expiresAt: expiresAt,
+            sessionId: sessionId2
+        )
+
+        let revoked = try await store.revokeRefreshTokens(for: user1)
+        #expect(revoked.contains(sessionId1))
+        #expect(!revoked.contains(sessionId2))
+
+        let user2Token = try await store.find(refreshTokenHash: "hash-2")
+        #expect(user2Token?.revokedAt == nil)
+    }
+
+    @Test
+    func `revokeRefreshTokens for user with nil id returns empty array`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user = MockUser(
+            id: nil,
+            email: "user@example.com",
+            phone: nil,
+            username: nil,
+            passwordHash: "hash",
+            isAnonymous: false,
+            isEmailVerified: false,
+            isPhoneVerified: false
+        )
+
+        let revoked = try await store.revokeRefreshTokens(for: user)
+
+        #expect(revoked == [])
+    }
+
+    @Test
+    func `revokeRefreshTokens sessionId only revokes that session`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+        let sessionId1 = UUID()
+        let sessionId2 = UUID()
+
+        try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-1",
+            expiresAt: expiresAt,
+            sessionId: sessionId1
+        )
+        try await store.createRefreshToken(
+            for: user,
+            tokenHash: "hash-2",
+            expiresAt: expiresAt,
+            sessionId: sessionId2
+        )
+
+        try await store.revokeRefreshTokens(sessionId: sessionId1)
+
+        let token1 = try await store.find(refreshTokenHash: "hash-1")
+        let token2 = try await store.find(refreshTokenHash: "hash-2")
+
+        #expect(token1?.revokedAt != nil)
+        #expect(token2?.revokedAt == nil)
+    }
+
+    @Test
+    func `revokeRefreshTokens sessionId leaves other users tokens untouched`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user1 = makeUser()
+        let user2 = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+        let sessionId = UUID()
+
+        try await store.createRefreshToken(
+            for: user1,
+            tokenHash: "hash-1",
+            expiresAt: expiresAt,
+            sessionId: sessionId
+        )
+        try await store.createRefreshToken(
+            for: user2,
+            tokenHash: "hash-2",
+            expiresAt: expiresAt,
+            sessionId: UUID()
+        )
+
+        try await store.revokeRefreshTokens(sessionId: sessionId)
+
+        let user2Token = try await store.find(refreshTokenHash: "hash-2")
+        #expect(user2Token?.revokedAt == nil)
+    }
+
+    @Test
+    func `transaction returns body result`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let result = try await inMemoryStore.transaction { _ in
+            return 42
+        }
+
+        #expect(result == 42)
+    }
+
+    @Test
+    func `transaction creates rows when body succeeds`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+
+        try await inMemoryStore.transaction { _ in
+            try await store.createRefreshToken(
+                for: user,
+                tokenHash: "hash-tx",
+                expiresAt: expiresAt,
+                sessionId: UUID()
+            )
+        }
+
+        let found = try await store.find(refreshTokenHash: "hash-tx")
+        #expect(found != nil)
+    }
+
+    @Test
+    func `transaction rolls back on error`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        let store = inMemoryStore.tokens
+        let user = makeUser()
+        let expiresAt = Date().addingTimeInterval(3600)
+
+        struct TestError: Error {}
+
+        do {
+            try await inMemoryStore.transaction { _ in
+                try await store.createRefreshToken(
+                    for: user,
+                    tokenHash: "hash-rollback",
+                    expiresAt: expiresAt,
+                    sessionId: UUID()
+                )
+                throw TestError()
+            }
+        } catch is TestError {
+        }
+
+        let found = try await store.find(refreshTokenHash: "hash-rollback")
+        #expect(found == nil)
+    }
+
+    @Test
+    func `transaction propagates error after rollback`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+
+        struct TestError: Error, Equatable {}
+
+        await #expect(throws: TestError.self) {
+            try await inMemoryStore.transaction { _ in
+                throw TestError()
+            }
+        }
+    }
+
+    @Test
+    func `transaction hands the same store to body`() async throws {
+        let inMemoryStore = Passage.OnlyForTest.InMemoryStore()
+        final class Capture: @unchecked Sendable {
+            var storeTokensMatch = false
+        }
+        let capture = Capture()
+
+        try await inMemoryStore.transaction { store in
+            capture.storeTokensMatch = (store.tokens as? Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore) === (inMemoryStore.tokens as? Passage.OnlyForTest.InMemoryStore.InMemoryTokenStore)
+        }
+
+        #expect(capture.storeTokensMatch)
+    }
+
+}

--- a/Tests/PassageTests/Unit/Services/PasskeyChallengeStoreProtocolTests.swift
+++ b/Tests/PassageTests/Unit/Services/PasskeyChallengeStoreProtocolTests.swift
@@ -233,6 +233,9 @@ struct `PasskeyChallengeStore Protocol Tests` {
             var restorationCodes: any Passage.RestorationCodeStore { fatalError() }
             var magicLinkTokens: any Passage.MagicLinkTokenStore { fatalError() }
             var exchangeTokens: any Passage.ExchangeTokenStore { fatalError() }
+            func transaction<T: Sendable>(_ body: @Sendable (any Passage.Store) async throws -> T) async throws -> T {
+                try await body(self)
+            }
             var passkeyChallenges: (any Passage.PasskeyChallengeStore)? { MockPasskeyChallengeStore() }
         }
 
@@ -249,7 +252,9 @@ struct `PasskeyChallengeStore Protocol Tests` {
             var restorationCodes: any Passage.RestorationCodeStore { fatalError() }
             var magicLinkTokens: any Passage.MagicLinkTokenStore { fatalError() }
             var exchangeTokens: any Passage.ExchangeTokenStore { fatalError() }
-            // default-nil extension applies to passkeyChallenges
+            func transaction<T: Sendable>(_ body: @Sendable (any Passage.Store) async throws -> T) async throws -> T {
+                try await body(self)
+            }
         }
 
         let store: any Passage.Store = LegacyStore()

--- a/Tests/PassageTests/Unit/Services/PasskeyCredentialStoreProtocolTests.swift
+++ b/Tests/PassageTests/Unit/Services/PasskeyCredentialStoreProtocolTests.swift
@@ -219,6 +219,9 @@ struct `PasskeyCredentialStore Protocol Tests` {
             var restorationCodes: any Passage.RestorationCodeStore { fatalError() }
             var magicLinkTokens: any Passage.MagicLinkTokenStore { fatalError() }
             var exchangeTokens: any Passage.ExchangeTokenStore { fatalError() }
+            func transaction<T: Sendable>(_ body: @Sendable (any Passage.Store) async throws -> T) async throws -> T {
+                try await body(self)
+            }
             var passkeyCredentials: (any Passage.PasskeyCredentialStore)? { MockPasskeyCredentialStore() }
         }
 
@@ -235,6 +238,9 @@ struct `PasskeyCredentialStore Protocol Tests` {
             var restorationCodes: any Passage.RestorationCodeStore { fatalError() }
             var magicLinkTokens: any Passage.MagicLinkTokenStore { fatalError() }
             var exchangeTokens: any Passage.ExchangeTokenStore { fatalError() }
+            func transaction<T: Sendable>(_ body: @Sendable (any Passage.Store) async throws -> T) async throws -> T {
+                try await body(self)
+            }
             // Intentionally no passkeyCredentials override — default-nil extension applies.
         }
 

--- a/Tests/PassageTests/Unit/Services/ServicesTests.swift
+++ b/Tests/PassageTests/Unit/Services/ServicesTests.swift
@@ -56,16 +56,31 @@ struct `Services Tests` {
     }
 
     struct MockTokenStore: Passage.TokenStore {
-        func createRefreshToken(for user: any User, tokenHash hash: String, expiresAt: Date) async throws -> any RefreshToken {
+
+        func createRefreshToken(
+            for user: any User,
+            tokenHash hash: String,
+            expiresAt: Date,
+            sessionId: UUID
+        ) async throws -> any RefreshToken {
             fatalError()
         }
-        func createRefreshToken(for user: any User, tokenHash hash: String, expiresAt: Date, replacing tokenToReplace: (any RefreshToken)?) async throws -> any RefreshToken {
+
+        func createRefreshToken(
+            for user: any User,
+            tokenHash hash: String,
+            expiresAt: Date,
+            sessionId: UUID,
+            replacing tokenToReplace: (any RefreshToken)?
+        ) async throws -> any RefreshToken {
             fatalError()
         }
+
         func find(refreshTokenHash hash: String) async throws -> (any RefreshToken)? { nil }
-        func revokeRefreshToken(for user: any User) async throws {}
+        func revokeRefreshTokens(for user: any User) async throws -> [UUID] { [] }
         func revokeRefreshToken(withHash hash: String) async throws {}
         func revoke(refreshTokenFamilyStartingFrom token: any RefreshToken) async throws {}
+        func revokeRefreshTokens(sessionId: UUID) async throws {}
     }
 
     struct MockVerificationCodeStore: Passage.VerificationCodeStore {
@@ -111,6 +126,9 @@ struct `Services Tests` {
         var restorationCodes: any Passage.RestorationCodeStore { MockRestorationCodeStore() }
         var magicLinkTokens: any Passage.MagicLinkTokenStore { MockMagicLinkTokenStore() }
         var exchangeTokens: any Passage.ExchangeTokenStore { MockExchangeTokenStore() }
+        func transaction<T: Sendable>(_ body: @Sendable (any Passage.Store) async throws -> T) async throws -> T {
+            try await body(self)
+        }
     }
 
     struct MockEmailDelivery: Passage.EmailDelivery {

--- a/Tests/PassageTests/Unit/Services/StoreProtocolsTests.swift
+++ b/Tests/PassageTests/Unit/Services/StoreProtocolsTests.swift
@@ -35,6 +35,7 @@ struct `Store Protocols Tests` {
         var expiresAt: Date
         var revokedAt: Date?
         var replacedBy: UUID?
+        var sessionId: UUID
     }
 
     struct MockEmailVerificationCode: EmailVerificationCode {
@@ -148,7 +149,8 @@ struct `Store Protocols Tests` {
         func createRefreshToken(
             for user: any User,
             tokenHash hash: String,
-            expiresAt: Date
+            expiresAt: Date,
+            sessionId: UUID
         ) async throws -> any RefreshToken {
             MockRefreshToken(
                 id: UUID(),
@@ -156,7 +158,8 @@ struct `Store Protocols Tests` {
                 tokenHash: hash,
                 expiresAt: expiresAt,
                 revokedAt: nil,
-                replacedBy: nil
+                replacedBy: nil,
+                sessionId: sessionId
             )
         }
 
@@ -164,6 +167,7 @@ struct `Store Protocols Tests` {
             for user: any User,
             tokenHash hash: String,
             expiresAt: Date,
+            sessionId: UUID,
             replacing tokenToReplace: (any RefreshToken)?
         ) async throws -> any RefreshToken {
             MockRefreshToken(
@@ -172,7 +176,8 @@ struct `Store Protocols Tests` {
                 tokenHash: hash,
                 expiresAt: expiresAt,
                 revokedAt: nil,
-                replacedBy: tokenToReplace?.id as? UUID
+                replacedBy: tokenToReplace?.id as? UUID,
+                sessionId: sessionId
             )
         }
 
@@ -180,8 +185,8 @@ struct `Store Protocols Tests` {
             nil
         }
 
-        func revokeRefreshToken(for user: any User) async throws {
-            // Method signature test
+        func revokeRefreshTokens(for user: any User) async throws -> [UUID] {
+            []
         }
 
         func revokeRefreshToken(withHash hash: String) async throws {
@@ -189,6 +194,10 @@ struct `Store Protocols Tests` {
         }
 
         func revoke(refreshTokenFamilyStartingFrom token: any RefreshToken) async throws {
+            // Method signature test
+        }
+
+        func revokeRefreshTokens(sessionId: UUID) async throws {
             // Method signature test
         }
     }
@@ -454,6 +463,9 @@ struct `Store Protocols Tests` {
         var restorationCodes: any Passage.RestorationCodeStore { MockRestorationCodeStore() }
         var magicLinkTokens: any Passage.MagicLinkTokenStore { MockMagicLinkTokenStore() }
         var exchangeTokens: any Passage.ExchangeTokenStore { MockExchangeTokenStore() }
+        func transaction<T: Sendable>(_ body: @Sendable (any Passage.Store) async throws -> T) async throws -> T {
+            try await body(self)
+        }
     }
 
     @Test

--- a/Tests/PassageTests/Unit/Types/AccessTokenTests.swift
+++ b/Tests/PassageTests/Unit/Types/AccessTokenTests.swift
@@ -19,7 +19,8 @@ struct `Access Token Tests` {
             expiresAt: expiresAt,
             issuer: "https://example.com",
             audience: "api.example.com",
-            scope: "read write"
+            scope: "read write",
+            sessionId: UUID()
         )
 
         #expect(token.subject.value == "user123")
@@ -39,7 +40,8 @@ struct `Access Token Tests` {
             expiresAt: expiresAt,
             issuer: nil,
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         #expect(token.subject.value == "user123")
@@ -58,7 +60,8 @@ struct `Access Token Tests` {
             expiresAt: expiresAt,
             issuer: nil,
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         let afterCreation = Date()
@@ -80,7 +83,8 @@ struct `Access Token Tests` {
             expiresAt: Date(timeIntervalSinceNow: 3600),
             issuer: nil,
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         #expect(token.subject.value == userId)
@@ -95,7 +99,8 @@ struct `Access Token Tests` {
             expiresAt: expirationDate,
             issuer: nil,
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         #expect(token.expiration.value.timeIntervalSince1970 == expirationDate.timeIntervalSince1970)
@@ -111,7 +116,8 @@ struct `Access Token Tests` {
             expiresAt: Date(timeIntervalSinceNow: 3600),
             issuer: nil,
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         #expect(token.issuedAt.value.timeIntervalSince1970 == issuedAtDate.timeIntervalSince1970)
@@ -128,7 +134,8 @@ struct `Access Token Tests` {
             expiresAt: Date(timeIntervalSinceNow: 3600),
             issuer: issuer,
             audience: nil,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         #expect(token.issuer?.value == issuer)
@@ -145,7 +152,8 @@ struct `Access Token Tests` {
             expiresAt: Date(timeIntervalSinceNow: 3600),
             issuer: nil,
             audience: audience,
-            scope: nil
+            scope: nil,
+            sessionId: UUID()
         )
 
         #expect(token.audience?.value.first == audience)
@@ -162,7 +170,8 @@ struct `Access Token Tests` {
             expiresAt: Date(timeIntervalSinceNow: 3600),
             issuer: nil,
             audience: nil,
-            scope: scope
+            scope: scope,
+            sessionId: UUID()
         )
 
         #expect(token.scope == scope)
@@ -177,7 +186,8 @@ struct `Access Token Tests` {
             expiresAt: Date(timeIntervalSinceNow: 3600),
             issuer: "issuer1",
             audience: "audience1",
-            scope: "read"
+            scope: "read",
+            sessionId: UUID()
         )
 
         let token2 = AccessToken(
@@ -185,7 +195,8 @@ struct `Access Token Tests` {
             expiresAt: Date(timeIntervalSinceNow: 7200),
             issuer: "issuer2",
             audience: "audience2",
-            scope: "write"
+            scope: "write",
+            sessionId: UUID()
         )
 
         #expect(token1.subject.value != token2.subject.value)
@@ -193,4 +204,24 @@ struct `Access Token Tests` {
         #expect(token1.audience?.value.first != token2.audience?.value.first)
         #expect(token1.scope != token2.scope)
     }
+
+    // MARK: - Session ID Tests
+
+    @Test
+    func `Access token initialization with sessionId`() {
+        let sessionId = UUID()
+        let expiresAt = Date(timeIntervalSinceNow: 3600)
+
+        let token = AccessToken(
+            userId: "user123",
+            expiresAt: expiresAt,
+            issuer: nil,
+            audience: nil,
+            scope: nil,
+            sessionId: sessionId
+        )
+
+        #expect(token.sessionId == sessionId)
+    }
+
 }

--- a/Tests/PassageTests/Unit/Types/CredentialIssuanceTests.swift
+++ b/Tests/PassageTests/Unit/Types/CredentialIssuanceTests.swift
@@ -1,0 +1,275 @@
+@testable import Passage
+@testable import PassageOnlyForTest
+import Foundation
+import Testing
+
+@Suite(.tags(.unit))
+struct `Credential Issuance Tests` {
+
+    private struct MockUser: User {
+        typealias Id = UUID
+        var id: UUID?
+        var email: String?
+        var phone: String?
+        var username: String?
+        var passwordHash: String?
+        var isAnonymous: Bool
+        var isEmailVerified: Bool
+        var isPhoneVerified: Bool
+
+        var sessionID: String {
+            guard let id = id else { fatalError("MockUser must have an ID") }
+            return id.uuidString
+        }
+    }
+
+    private func makeUser() -> MockUser {
+        MockUser(
+            id: UUID(),
+            email: "user@example.com",
+            phone: nil,
+            username: nil,
+            passwordHash: "hash",
+            isAnonymous: false,
+            isEmailVerified: false,
+            isPhoneVerified: false
+        )
+    }
+
+    @Test
+    func `init stores kind`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let kind = CredentialIssuance.Kind.bearer
+        let issuance = CredentialIssuance(
+            kind: kind,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+
+        #expect(issuance.kind == kind)
+    }
+
+    @Test
+    func `init stores origin`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let origin = CredentialIssuance.Origin.login
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: origin,
+            user: makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+
+        #expect(issuance.origin == origin)
+    }
+
+    @Test
+    func `init stores user`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let user = makeUser()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: user,
+            sessionId: UUID(),
+            store: store
+        )
+
+        #expect((try? issuance.user.requiredIdAsString) == (try? user.requiredIdAsString))
+    }
+
+    @Test
+    func `init stores sessionId`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let sessionId = UUID()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: sessionId,
+            store: store
+        )
+
+        #expect(issuance.sessionId == sessionId)
+    }
+
+    @Test
+    func `init optional accessToken defaults to nil`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+
+        #expect(issuance.accessToken == nil)
+    }
+
+    @Test
+    func `init optional accessToken stores provided value`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let token = "test-token"
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            accessToken: token,
+            store: store
+        )
+
+        #expect(issuance.accessToken == token)
+    }
+
+    @Test
+    func `init optional accessTokenExpiresAt defaults to nil`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+
+        #expect(issuance.accessTokenExpiresAt == nil)
+    }
+
+    @Test
+    func `init optional accessTokenExpiresAt stores provided value`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let expiresAt = Date()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            accessTokenExpiresAt: expiresAt,
+            store: store
+        )
+
+        #expect(issuance.accessTokenExpiresAt == expiresAt)
+    }
+
+    @Test
+    func `init optional refreshTokenExpiresAt defaults to nil`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+
+        #expect(issuance.refreshTokenExpiresAt == nil)
+    }
+
+    @Test
+    func `init optional refreshTokenExpiresAt stores provided value`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let expiresAt = Date()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            refreshTokenExpiresAt: expiresAt,
+            store: store
+        )
+
+        #expect(issuance.refreshTokenExpiresAt == expiresAt)
+    }
+
+    @Test
+    func `init revokedSessionIds defaults to empty array`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+
+        #expect(issuance.revokedSessionIds == [])
+    }
+
+    @Test
+    func `init revokedSessionIds stores provided value`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let ids = [UUID(), UUID()]
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            revokedSessionIds: ids,
+            store: store
+        )
+
+        #expect(issuance.revokedSessionIds == ids)
+    }
+
+    @Test
+    func `Kind bearer and browser are equatable and distinct`() {
+        #expect(CredentialIssuance.Kind.bearer == .bearer)
+        #expect(CredentialIssuance.Kind.browser == .browser)
+        #expect(CredentialIssuance.Kind.bearer != .browser)
+    }
+
+    @Test
+    func `Origin login and magicLink are distinct`() {
+        #expect(CredentialIssuance.Origin.login == .login)
+        #expect(CredentialIssuance.Origin.magicLink == .magicLink)
+        #expect(CredentialIssuance.Origin.login != .magicLink)
+    }
+
+    @Test
+    func `Origin refresh and exchange are distinct`() {
+        #expect(CredentialIssuance.Origin.refresh == .refresh)
+        #expect(CredentialIssuance.Origin.exchange == .exchange)
+        #expect(CredentialIssuance.Origin.refresh != .exchange)
+    }
+
+    @Test
+    func `Origin federatedLogin and passkey are distinct`() {
+        #expect(CredentialIssuance.Origin.federatedLogin == .federatedLogin)
+        #expect(CredentialIssuance.Origin.passkey == .passkey)
+        #expect(CredentialIssuance.Origin.federatedLogin != .passkey)
+    }
+
+    @Test
+    func `Origin accountLinking is distinct from others`() {
+        #expect(CredentialIssuance.Origin.accountLinking == .accountLinking)
+        #expect(CredentialIssuance.Origin.accountLinking != .login)
+        #expect(CredentialIssuance.Origin.accountLinking != .magicLink)
+    }
+
+    @Test
+    func `all seven Origin cases are distinct`() {
+        let origins: [CredentialIssuance.Origin] = [
+            .login, .magicLink, .refresh, .exchange, .federatedLogin, .passkey, .accountLinking
+        ]
+        let uniqueOrigins = Set(origins.map { "\($0)" })
+        #expect(uniqueOrigins.count == 7)
+    }
+
+    @Test
+    func `is Sendable`() {
+        let store = Passage.OnlyForTest.InMemoryStore()
+        let issuance = CredentialIssuance(
+            kind: .bearer,
+            origin: .login,
+            user: makeUser(),
+            sessionId: UUID(),
+            store: store
+        )
+        let _: any Sendable = issuance
+    }
+}

--- a/Tests/PassageTests/Unit/Types/TransportTests.swift
+++ b/Tests/PassageTests/Unit/Types/TransportTests.swift
@@ -1,0 +1,28 @@
+@testable import Passage
+import Testing
+
+@Suite(.tags(.unit))
+struct `Transport Tests` {
+
+    @Test
+    func `browser case equals itself`() {
+        #expect(Passage.Transport.browser == .browser)
+    }
+
+    @Test
+    func `bearer case equals itself`() {
+        #expect(Passage.Transport.bearer == .bearer)
+    }
+
+    @Test
+    func `browser and bearer are distinct`() {
+        #expect(Passage.Transport.browser != .bearer)
+        #expect(Passage.Transport.bearer != .browser)
+    }
+
+    @Test
+    func `is Sendable`() {
+        let _: any Sendable = Passage.Transport.browser
+        let _: any Sendable = Passage.Transport.bearer
+    }
+}


### PR DESCRIPTION
## Summary

- **Issuance hooks inside the store transaction.** `Passage.Hooks.Account` gains `willIssueCredential` (runs after the refresh-token row is written, before commit; a throw rolls the sign-in back) and `didIssueCredential` (after commit). A host that keeps its own session inventory no longer has to dual-write from the HTTP response.
- **Stable session id.** `sid` claim on `AccessToken`, required `sessionId` on refresh-token rows, carried forward across refresh. `request.passage.sessionId`, `request.passage.revoke(sessionId:)`, and a host-provided `isSessionRevoked` hook consulted by both the bearer and the session authenticators.
- **One credential per login.** New `Passage.Transport` and public `request.passage.login(_:origin:via:)`; routes choose cookie vs. bearer, feature methods return the user. Fixes the double session creation (cookie + orphaned refresh row) on form logins with sessions enabled, and the stray cookie set by the exchange endpoint.
- Docs: README "Session inventory in the host", Tokens/Passwordless feature guides, `DEVELOPER_NOTES.md`, new `CHANGELOG.md` (0.6.0 — minor bump, tag on release).

## Breaking

See `CHANGELOG.md › Breaking`. Store implementors: `Store.transaction` is required; `RefreshToken.sessionId: UUID`; `TokenStore.createRefreshToken(..., sessionId:)`, `revokeRefreshTokens(for:) -> [UUID]`, `revokeRefreshTokens(sessionId:)`. `verifyEmailMagicLink(token:)` returns `any User`. Companion PR: rozd/passage-fluent (requires this repo tagged `0.6.0`).

## Test plan

- [x] `swift test --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable` — 1527 tests / 138 suites pass
- [x] Per issuance path (login, magic link, exchange, refresh, browser): hook throws → route fails and no refresh-token row; hook succeeds → row and returned `sid` agree
- [x] Refresh preserves `sid`; `revoke(sessionId:)` makes the next refresh fail
- [x] `isSessionRevoked` returning true rejects an otherwise-valid bearer and a cookie session
- [x] passage-fluent suite (285 tests) passes against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYivLwVT4hDu9h1T9CsXwh
